### PR TITLE
fix: ステータスラインのコマンドパスを修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "statusLine": {
     "type": "command",
-    "command": "bash /workspaces/life/.claude/status-line-command.sh"
+    "command": "bash /workspaces/agent-team-studio/.claude/status-line-command.sh"
   }
 }


### PR DESCRIPTION
## Summary
- `.claude/settings.json` のステータスラインコマンドのパスを正しいワークスペースパス (`/workspaces/agent-team-studio/`) に修正

## Test plan
- [x] ステータスラインが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)