### PR TITLE
chore: Claude Code の権限設定を整備

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,9 +5,29 @@
   },
   "permissions": {
     "allow": [
+      "Bash(git add:*)",
+      "Bash(git branch:*)",
       "Bash(git checkout:*)",
+      "Bash(git commit:*)",
+      "Bash(git diff:*)",
       "Bash(git fetch:*)",
-      "Bash(git pull:*)"
+      "Bash(git log:*)",
+      "Bash(git merge:*)",
+      "Bash(git pull:*)",
+      "Bash(git push:*)",
+      "Bash(git rebase:*)",
+      "Bash(git stash:*)",
+      "Bash(git status:*)",
+      "Bash(ls:*)",
+      "Bash(gh pr create:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push --force:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean -f:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- 日常的に使用する git コマンド（diff, log, status, branch, stash, merge, rebase, push）と `ls` を allow に追加
- 破壊的操作（`git push --force`, `git reset --hard`, `git clean -f`, `rm -rf`）を deny に設定
- 外部通信コマンド（`curl`, `wget`）を deny に設定（WebFetch ツールで代替可能）

## Test plan
- [x] Claude Code で allow 対象のコマンドが確認なしで実行されること
- [x] deny 対象のコマンドがブロックされること

```bash
- **allow**: `git status` — 確認なしで実行されました
- **deny**: `curl` — ブロックされました

どちらも想定通り動作しています。
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)