### PR TITLE
chore(project): コミットメッセージに Scope 規約を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,9 @@
 ## コーディング規約
 
 - **コミット**: conventional commits 形式 — `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`。意味のある単位でコミットする
+  - **Scope**: `type(scope):` 形式でスコープを付与する。プロダクト開発の進行に合わせて拡張する
+  - 現在のスコープ: `adr`, `ci`, `project`（プロジェクト管理・設定）
+  - パッケージ追加時はパッケージ名をスコープとして使用する
 - **TypeScript**: strict モード有効、`any` の使用を避ける
 - **インポート**: パッケージ間の依存には workspace プロトコル（`workspace:*`）を使用
 


### PR DESCRIPTION
## Summary
- Conventional Commits に `type(scope):` 形式の Scope 規約を導入
- 現時点のスコープ: `adr`, `ci`, `project`（最小限で開始し、パッケージ追加に応じて拡張）
- CLAUDE.md のコーディング規約セクションを更新

## Test plan
- [x] CLAUDE.md の記述が正しいことを確認
- [x] 今後のコミットで scope 付き形式が使えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)