### PR TITLE
chore(project): Claude Code スキルの構造改善と Issue/ADR スキル追加

### DIFF
--- a/.claude/skills/create-adr/SKILL.md
+++ b/.claude/skills/create-adr/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: create-adr
+description: プロジェクト規約に沿った ADR（Architecture Decision Record）を作成する。テンプレートに従って ADR ファイルを生成し、README の一覧表を更新する。
+when_to_use: ユーザーが「ADR作って」「ADR書いて」「意思決定を記録して」「決定を残して」「ADR化して」などと言ったとき
+argument-hint: "[title-or-topic]"
+allowed-tools: Bash(gh issue view:*) Bash(gh issue list:*) Read Grep Edit Write Glob
+---
+
+# create-adr
+
+プロジェクトの規約に従って ADR を作成する。
+`$ARGUMENTS` から ADR のタイトルやトピックを判断する。
+
+ADR テンプレート:
+
+!`cat docs/adr/template.md`
+
+既存 ADR 一覧:
+
+!`cat docs/adr/README.md`
+
+## 前提知識
+
+- ADR は Michael Nygard の軽量フォーマットに基づく（ADR-0001 で決定済み）
+- ADR の目的は「なぜその選択をしたか」を後から追跡可能にすること
+- decision Issue で議論した結果を ADR に記録する、という流れが基本
+
+## 手順
+
+### 1. 次の ADR 番号の決定
+
+上記の既存 ADR 一覧から最大の番号 + 1 を新しい ADR 番号とする。
+
+### 2. 決定内容の把握
+
+ユーザーの入力から以下を整理する:
+
+- **何についての決定か**（タイトル）
+- **なぜ決定が必要だったか**（Context）
+- **検討した選択肢とその比較**
+- **何を選んだか、なぜか**（Decision）
+- **どういう影響があるか**（Consequences）
+
+情報が不足している場合:
+
+- 関連する Issue（特に decision ラベル付き）があれば `gh issue view` で内容を確認する
+- コードベースや既存 ADR から関連する背景情報を収集する
+- それでも不足する場合はユーザーに質問する
+
+### 3. ADR ファイルの作成
+
+上記のテンプレートの構造に従い作成する。
+
+**ファイル名**: `docs/adr/NNNN-kebab-case-title.md`
+
+- 番号は4桁ゼロ埋め（例: `0004`）
+- タイトルは英語の kebab-case（例: `choose-database`, `adopt-monorepo`）
+
+**Consequences の構造**: 既存 ADR に倣い、以下の3分類で記述する:
+
+- **ポジティブ**: 良い影響
+- **ネガティブ / リスク**: 悪い影響。リスクには必ず対策を併記する（→ 対策: ...）
+- **中立**: どちらでもない影響
+
+### 4. ADR 品質のセルフチェック
+
+作成した ADR が以下の基準を満たしているか確認する:
+
+- [ ] **Context が自己完結的か**: この ADR だけ読んで「なぜこの決定が必要だったか」がわかるか
+- [ ] **Decision が明確か**: 何を選び、何を選ばなかったかが明確か
+- [ ] **Consequences が正直か**: ネガティブな影響も隠さず書いているか
+- [ ] **適切な粒度か**: 1つの ADR で1つの決定を扱っているか
+
+### 5. README の一覧表を更新
+
+`docs/adr/README.md` の ADR 一覧テーブルに新しいエントリを追加する。
+
+- 日付は本日の日付を使用する
+- ステータスは原則 `proposed`（ユーザーが accepted を指定した場合はそちらを使用）
+
+### 6. 関連 Issue の処理
+
+- 対応する decision Issue がある場合、ADR を作成した旨をユーザーに伝える（Issue のクローズはユーザー判断）
+- ADR の中で Issue 番号に言及する場合は `#XX` 形式で参照する
+
+### 7. ユーザーへの提示
+
+作成した ADR の全文をユーザーに提示し、確認を求める。以下の点について特にフィードバックを促す:
+
+- Context の記述が背景を正確に反映しているか
+- Decision の記述が決定内容を正しく表しているか
+- Consequences に漏れがないか
+
+## Status の運用ルール
+
+| ステータス | いつ使うか |
+| ----------- | ----------- |
+| `proposed` | 新規作成時のデフォルト。議論が必要な場合 |
+| `accepted` | ユーザーが承認した場合。自明な決定は最初から accepted でもよい |
+| `deprecated` | 決定が古くなり、もう従う必要がない場合 |
+| `superseded by [NNNN](./NNNN-title.md)` | 新しい ADR で置き換えられた場合 |
+
+## 注意点
+
+- **ユーザーの意思決定を尊重する**: ADR の内容（特に Decision）はユーザーが判断するもの。Claude は選択肢や根拠を提示するが、決定自体はユーザーに委ねる
+- **既存 ADR との整合性**: 新しい ADR が既存の ADR と矛盾する場合は、既存 ADR のステータスを `superseded` に更新することを提案する
+- **過度に形式的にしない**: 内容が薄いセクション（例: 自明な決定の Consequences）は簡潔でよい
+- **コミット**: CLAUDE.md のコミット規約に従い `docs(adr): NNNN タイトル` 形式を使用する

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: create-issue
+description: プロジェクト規約に沿った GitHub Issue を作成する。Issue の種別に応じたテンプレート構造で本文を生成し、適切なラベルを付与して gh issue create を実行する。
+when_to_use: ユーザーが「Issue作って」「issue立てて」「チケット作って」「バグ報告して」「機能要望出して」「タスク作って」などと言ったとき
+argument-hint: "[issue-type] [title-or-description]"
+allowed-tools: Bash(gh issue create:*) Bash(gh issue list:*) Bash(gh issue view:*) Bash(gh label list:*) Read Grep
+---
+
+# create-issue
+
+プロジェクトの規約に従って GitHub Issue を作成する。
+`$ARGUMENTS` から Issue の種別とタイトル・内容を判断する。
+
+Issue テンプレート:
+
+```!
+cat .github/ISSUE_TEMPLATE/bug.yml
+cat .github/ISSUE_TEMPLATE/feature.yml
+cat .github/ISSUE_TEMPLATE/decision.yml
+cat .github/ISSUE_TEMPLATE/task.yml
+```
+
+## 手順
+
+### 1. Issue 種別の判定
+
+ユーザーの入力から Issue の種別を判定する。明示されていない場合は内容から推測し、確信が持てなければユーザーに確認する。
+
+| 種別 | 判定キーワード例 |
+| ------ | ----------------- |
+| **bug** | バグ、不具合、エラー、動かない、壊れた |
+| **feature** | 機能、追加、〜したい、〜できるようにする |
+| **decision** | 決定、選定、方針、どうするか、ADR |
+| **task** | タスク、chore、設定、整備、対応 |
+
+### 2. コンテキストの収集
+
+Issue の内容を充実させるために、必要に応じて以下を確認する:
+
+- 既存の関連 Issue: `gh issue list --state open` で重複や関連がないか確認
+- ADR や docs との関連: 既存の意思決定や設計ドキュメントを参照
+- コードベースの状態: バグ報告の場合、関連するコードを確認
+
+### 3. Issue 本文の生成
+
+上記で読み込んだ種別ごとのテンプレート構造に従って本文を生成する。ユーザーが与えた情報を適切なセクションに配置し、不足している必須セクションがあればユーザーに確認する。
+
+### 4. ラベルの選定
+
+以下のルールに従ってラベルを付与する。
+
+**タイプラベル（必須・1つ）**:
+
+| 種別 | タイプラベル |
+| ------ | ------------- |
+| bug | `bug` |
+| feature | `enhancement`, `requirement` |
+| decision | `decision` |
+| task | `chore` |
+
+**フェーズラベル（必須・1つ）**: 作業が属するフェーズを判断して付与する
+
+| フェーズ | 内容 |
+| --------- | ------ |
+| `phase:planning` | 企画（コンセプト、方針策定） |
+| `phase:requirements` | 要件定義（スコープ、ユーザー定義） |
+| `phase:design` | 設計（アーキテクチャ、技術選定） |
+| `phase:development` | 開発（実装、CI/CD） |
+| `phase:testing` | 試験 |
+| `phase:improvement` | 改善 |
+| `phase:operations` | 運用保守 |
+
+**優先度ラベル（任意）**: ユーザーが明示した場合のみ付与する — `priority:high` / `priority:low`
+
+**その他のラベル（該当する場合）**: `documentation`, `design`, `test`
+
+### 5. Issue タイトルの生成
+
+- 日本語で、何をするか / 何が問題かを簡潔に表現する
+- 動詞で終わる体言止めまたは名詞句を推奨（例:「ターゲットユーザーの定義」「ログイン画面でエラーが発生する」）
+- **50文字以内**を目安にする
+
+### 6. ユーザーへの確認
+
+Issue を作成する前に、以下の内容をユーザーに提示して確認を取る:
+
+- **タイトル**
+- **ラベル**
+- **本文**（要約または全文）
+- 関連する既存 Issue があればその旨
+
+ユーザーが「おまかせ」「そのままでいい」と言った場合は確認をスキップしてよい。
+
+### 7. Issue 作成
+
+```bash
+gh issue create --title "<タイトル>" --body "<本文>" --label "<ラベル1>" --label "<ラベル2>"
+```
+
+- 作成後、Issue の URL と番号を表示する
+- 関連する Issue や ADR がある場合はその旨も伝える
+
+## 注意点
+
+- **重複チェック**: 類似の Issue が既に存在する場合はユーザーに報告し、新規作成するか既存 Issue への追記にするか判断を仰ぐ
+- **情報不足時の対応**: ユーザーの入力が曖昧な場合は、テンプレートの必須セクションを満たすために質問する。ただし過度な質問は避け、合理的に推測できる部分は埋める
+- **decision Issue と ADR の関係**: decision 種別の Issue は議論・検討の場であり、結論が出たら ADR として記録する流れになる。Issue 本文にその旨を記載するとよい

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -3,12 +3,16 @@ name: create-pr
 description: プロジェクト規約に沿った PR を作成する。ブランチの変更内容を解析し、PR テンプレートに沿った本文を生成して gh pr create を実行する。
 when_to_use: ユーザーが「PR作って」「プルリクエスト作成して」「PR出して」「マージしたい」などと言ったとき
 argument-hint: "[issue-number]"
-allowed-tools: Bash(git *) Bash(gh pr *) Read Grep
+allowed-tools: Bash(git status:*) Bash(git log:*) Bash(git diff:*) Bash(git push:*) Bash(gh pr create:*) Bash(gh pr view:*) Read Grep
 ---
 
 # create-pr
 
 プロジェクトの規約に従って、現在のブランチから PR を作成する。
+
+PR テンプレート:
+
+!`cat .github/PULL_REQUEST_TEMPLATE.md`
 
 ## 手順
 
@@ -27,37 +31,22 @@ allowed-tools: Bash(git *) Bash(gh pr *) Read Grep
 
 ### 3. 対応 Issue の特定
 
-- コミットメッセージやブランチ名から Issue 番号を推測する
+- `$ARGUMENTS` で Issue 番号が指定されていればそれを使用する
+- 指定がなければコミットメッセージやブランチ名から推測する
 - 特定できない場合はユーザーに確認する（任意、なしでも可）
 
 ### 4. PR 本文の生成
 
-`.github/PULL_REQUEST_TEMPLATE.md` の構造に従い、以下のセクションで本文を構成する:
+上記の PR テンプレートの構造に従って本文を構成する:
 
-```markdown
-## What
-
-<!-- 変更内容の簡潔な説明（コミット履歴・差分から要約） -->
-
-## Why
-
-<!-- 対応する Issue がある場合: closes #XX -->
-<!-- Issue がない場合: 変更の動機を記載 -->
-
-## How
-
-<!-- 実装アプローチの説明。変更が小さい（ファイル数3以下かつ差分50行以内）場合は「軽微な変更のため省略」と記載 -->
-
-## Checklist
-
-- [ ] テストが通ること（該当する場合）
-- [ ] ドキュメントを更新したこと（該当する場合）
-```
+- **What**: コミット履歴・差分から変更内容を要約
+- **Why**: 対応 Issue がある場合は `closes #XX`、ない場合は動機を記載
+- **How**: 実装アプローチ。変更が小さい（ファイル数3以下かつ差分50行以内）場合は「軽微な変更のため省略」
+- **Checklist**: テンプレートのチェックリストをそのまま含める
 
 ### 5. PR タイトルの生成
 
-- Conventional Commits のプレフィックス（`feat:`, `fix:`, `chore:`, `docs:` 等）で始める
-- スコープがある場合は `type(scope):` 形式にする
+- CLAUDE.md のコミット規約に従い、Conventional Commits プレフィックスで始める
 - **70文字以内**に収める
 - コミットが1つの場合はそのコミットメッセージをベースにする
 
@@ -72,11 +61,4 @@ allowed-tools: Bash(git *) Bash(gh pr *) Read Grep
 gh pr create --title "<タイトル>" --body "<本文>"
 ```
 
-- `--base main` はデフォルトなので省略可
 - 作成後、PR の URL を表示する
-
-## 規約リファレンス
-
-- ブランチ命名: `docs/guides/branch-strategy.md`
-- PR 運用ルール: `docs/guides/github-workflow.md`
-- コミット規約: `CLAUDE.md` のコーディング規約セクション


### PR DESCRIPTION
## What

- Claude Code スキルのファイル構造を公式仕様（`<name>/SKILL.md`）に移行
- `create-issue`、`create-adr` スキルを新規追加
- 既存 `create-pr` スキルのリファクタリング

## Why

- 既存の `create-pr.md` が公式のディレクトリ構造（`<name>/SKILL.md`）に沿っていなかった
- Issue 作成・ADR 作成を規約に沿って効率化するためスキル化が必要だった

## How

- 全スキルを `<name>/SKILL.md` ディレクトリ構造に移行
- テンプレートのハードコードを `!`cat ...`` による動的コンテキスト注入に置換
- `allowed-tools` を `Bash(git *)` から必要なサブコマンドのみに制限
- CLAUDE.md と重複する規約記述を参照に置き換え

## Checklist

- [x] テストが通ること（該当する場合）
- [x] ドキュメントを更新したこと（該当する場合）