### PR TITLE
chore(project): 権限設定とカスタム辞書の更新

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,7 @@
   "permissions": {
     "allow": [
       "Skill(create-adr)",
+      "Skill(create-issue)",
       "Skill(create-pr)",
       "Bash(git add:*)",
       "Bash(git branch:*)",
@@ -20,11 +21,14 @@
       "Bash(git rebase:*)",
       "Bash(git stash:*)",
       "Bash(git status:*)",
+      "Bash(git switch:*)",
       "Bash(grep:*)",
       "Bash(ls:*)",
+      "Bash(gh issue create:*)",
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
       "Bash(gh label list:*)",
+      "Bash(gh milestone list:*)",
       "Bash(gh pr create:*)",
       "Bash(gh pr view:*)"
     ],

--- a/cspell.json
+++ b/cspell.json
@@ -6,6 +6,7 @@
   "dictionaryDefinitions": [],
   "dictionaries": [],
   "words": [
+    "JTBD", // Jobs To Be Done
     "kuairen",
     "mctx",
     "msession",


### PR DESCRIPTION
## What

- Claude Code の権限設定に `create-issue` スキル、`git switch` / `gh issue create` / `gh milestone list` を追加
- cspell のカスタム辞書に "JTBD"（Jobs To Be Done）を追加

## Why

Issue 処理スキル導入（#25）やブランチ操作で必要な権限が不足していた。また ADR-0004, ADR-0005 で使用する JTBD がスペルチェック警告の対象になっていた。

## Checklist

- [x] テストが通ること（該当する場合）
- [x] ドキュメントを更新したこと（該当する場合）