### PR TITLE
feat(ci): Claude Code による PR 自動レビューワークフローを追加

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   review:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,6 +9,10 @@ permissions:
   pull-requests: write
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -2,7 +2,7 @@ name: Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 permissions:
   contents: read
@@ -16,12 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Run Claude Code review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          track_progress: true
           prompt: |
             /review pr ${{ github.event.pull_request.number }}
+          claude_args: |
+            --max-turns 10

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 jobs:
   review:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,29 @@
+name: Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code review
+        uses: anthropics/claude-code-action@v1
+        with:
+          prompt: |
+            /review pr ${{ github.event.pull_request.number }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -27,5 +27,7 @@ jobs:
           track_progress: true
           prompt: |
             /review pr ${{ github.event.pull_request.number }}
+
+            念のため `.claude/skills/review/SKILL.md` を読み込み、記載された手順と出力フォーマットに従ってレビューを実施してください。
           claude_args: |
             --max-turns 10

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Run Claude Code review
         uses: anthropics/claude-code-action@v1
         with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             /review pr ${{ github.event.pull_request.number }}
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,3 +51,4 @@
 - **PR テンプレート**: `.github/PULL_REQUEST_TEMPLATE.md` に定義
 - **ADR**: `docs/adr/` に記録。意思決定は規模を問わず ADR として残す
 - **ラベル**: タイプラベル（bug, enhancement, chore 等）を使用。ステータスは `status:blocked` のみ（ブロック時に付与）
+- **自動レビュー**: PR 作成・更新時に GitHub Actions が `review` スキルを自動実行し、結果を PR コメントに投稿する（`.github/workflows/review.yml`）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,4 +51,3 @@
 - **PR テンプレート**: `.github/PULL_REQUEST_TEMPLATE.md` に定義
 - **ADR**: `docs/adr/` に記録。意思決定は規模を問わず ADR として残す
 - **ラベル**: タイプラベル（bug, enhancement, chore 等）を使用。ステータスは `status:blocked` のみ（ブロック時に付与）
-- **自動レビュー**: PR 作成・更新時に GitHub Actions が `review` スキルを自動実行し、結果を PR コメントに投稿する（`.github/workflows/review.yml`）


### PR DESCRIPTION
## What

PR 作成時に Claude Code が自動でレビューを実行する GitHub Actions ワークフロー（`.github/workflows/review.yml`）を追加する。

- トリガー: `pull_request` の `opened`, `synchronize`, `ready_for_review`, `reopened`
- Draft PR はスキップ（`ready_for_review` への遷移時に初回レビュー）
- `anthropics/claude-code-action@v1` を使用し、`/review pr <num>` を実行
- 認証: `CLAUDE_CODE_OAUTH_TOKEN`（Secrets 登録済み）
- 進捗可視化: `track_progress: true`
- 暴走防止: `--max-turns 10` / `timeout-minutes: 15`

## Why

closes #60

選択肢 2（GitHub Actions による完全自動化）を採用。Claude Code 実行セッションに依存せず、夜間・週末の PR にも一貫してレビューが走る。レビュー観点は既存の review スキル（`.claude/skills/review/SKILL.md`）に委譲する前提。

## How

公式 example `examples/pr-review-comprehensive.yml` のパターンに準拠：

- `permissions`: `contents: read` / `pull-requests: write` / `id-token: write`（OIDC トークン生成用）
- `claude_code_oauth_token` input を使用（`anthropic_api_key` への OAuth トークン代入ではなく正規の input 名）
- `fetch-depth: 1`（`/review` 内部の `gh pr diff` は API 経由のため履歴不要）
- モデルはデフォルト（Sonnet）に委ねる

コミット履歴で検討経緯を残している：

1. `e2347dd` 初版追加
2. `dbbb96d` OAuth トークン認証に修正
3. `f940316` 不要な `issues:write` 権限を削除
4. `d6bd742` 公式 PR レビューパターンに準拠（`ready_for_review` / `track_progress` / `--max-turns`）
5. `4222598` `id-token: write` 権限追加

## Checklist

- [x] テストが通ること（該当する場合） — マージ後に本 PR 自体がワークフロー動作確認となる
- [ ] ドキュメントを更新したこと（該当する場合） — 運用が安定したら CLAUDE.md のセルフレビュー方針に追記予定