### PR TITLE
chore: settings に Bash(cat) の許可ルールを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,7 @@
       "Skill(resolve-review)",
       "Skill(review)",
       "Bash(bun run:*)",
+      "Bash(cat:*)",
       "Bash(ls:*)",
       "Bash(wc:*)",
       "Bash(git add:*)",


### PR DESCRIPTION
## What

`.claude/settings.json` の許可ルールに `Bash(cat:*)` を追加。

## Why

Claude Code が `cat` コマンドを確認なしで実行できるようにする。

## How

軽微な変更のため省略。

## Checklist

- [x] テストが通ること（該当する場合）
- [x] ドキュメントを更新したこと（該当する場合）