### PR TITLE
feat(shared): 型 SSoT 初版を移植 (#79)

### DIFF
--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -1,0 +1,159 @@
+/**
+ * REST API のリクエスト/レスポンス型。
+ *
+ * SSoT: docs/design/api-design.md
+ * 命名規約は api-design.md §レスポンス形式 の JSON 例に合わせて camelCase。
+ * URL/メソッド/ステータスの SSoT は設計 doc 側に残し、本ファイルはペイロードのみを扱う。
+ */
+
+import type {
+  AgentExecutionId,
+  AgentRole,
+  AgentStatus,
+  CompetitorAnalysisParameters,
+  CompetitorAnalysisResult,
+  ExecutionId,
+  ExecutionStatus,
+  IntegrationAgentOutput,
+  InvestigationAgentOutput,
+  ResultId,
+  TemplateDefinition,
+  TemplateId,
+} from "./domain-types.ts";
+
+// ---------- 共通 ----------
+
+/** 一覧取得時のレスポンス形式（api-design.md §レスポンス形式）。 */
+export type ListResponse<T> = {
+  items: T[];
+  total: number;
+};
+
+// ---------- エラー（api-design.md §エラーレスポンス） ----------
+
+/**
+ * REST エラーの discriminated union。errorCode で識別する。
+ * api-design.md §`errorCode` と HTTP ステータスの対応:
+ *   validation_error → 400 / not_found → 404 / internal_error → 500
+ */
+export type ApiError = ApiValidationError | ApiNotFoundError | ApiInternalError;
+
+export type ApiValidationError = {
+  errorCode: "validation_error";
+  message: string;
+  details: { field: string; reason: string }[];
+};
+
+export type ApiNotFoundError = {
+  errorCode: "not_found";
+  message: string;
+  /** resource は MVP リソースに限定したリテラル union（api-design.md 注）。 */
+  details: { resource: "template" | "execution"; id: string };
+};
+
+export type ApiInternalError = {
+  errorCode: "internal_error";
+  message: string;
+  /** MVP では省略を基本とし、将来のトレース導入余地として traceId を残す。 */
+  details?: { traceId?: string };
+};
+
+// ---------- GET /api/templates ----------
+
+/** 一覧用の軽量表現（definition は含めない）。 */
+export type TemplateSummary = {
+  id: TemplateId;
+  name: string;
+  description: string;
+};
+
+export type GetTemplatesResponse = ListResponse<TemplateSummary>;
+
+// ---------- GET /api/templates/:id ----------
+
+export type GetTemplateResponse = {
+  id: TemplateId;
+  name: string;
+  description: string;
+  definition: TemplateDefinition;
+  createdAt: string;
+  updatedAt: string;
+};
+
+// ---------- POST /api/executions ----------
+
+export type CreateExecutionRequest = {
+  templateId: TemplateId;
+  parameters: CompetitorAnalysisParameters;
+};
+
+/** 202 Accepted で返す軽量レスポンス（api-design.md §レスポンス形式 例）。 */
+export type CreateExecutionResponse = {
+  id: ExecutionId;
+  status: ExecutionStatus;
+  createdAt: string;
+};
+
+// ---------- GET /api/executions ----------
+
+export type ExecutionSummary = {
+  id: ExecutionId;
+  templateId: TemplateId;
+  status: ExecutionStatus;
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+};
+
+export type GetExecutionsResponse = ListResponse<ExecutionSummary>;
+
+// ---------- GET /api/executions/:id ----------
+
+type AgentExecutionDetailBase<R extends AgentRole, O> = {
+  id: AgentExecutionId;
+  agentId: string;
+  role: R;
+  status: AgentStatus;
+  output?: O;
+  errorMessage?: string;
+  startedAt?: string;
+  completedAt?: string;
+};
+
+export type InvestigationAgentExecutionDetail = AgentExecutionDetailBase<
+  "investigation",
+  InvestigationAgentOutput
+>;
+
+export type IntegrationAgentExecutionDetail = AgentExecutionDetailBase<
+  "integration",
+  IntegrationAgentOutput
+>;
+
+export type AgentExecutionDetail =
+  | InvestigationAgentExecutionDetail
+  | IntegrationAgentExecutionDetail;
+
+export type ResultDetail = {
+  id: ResultId;
+  markdown: string;
+  structured: CompetitorAnalysisResult;
+  createdAt: string;
+};
+
+/**
+ * Execution 詳細。AgentExecution と Result（任意）を併せて返す。
+ * Result の存在条件は data-model.md §3 不変条件 に従う。
+ */
+export type GetExecutionResponse = {
+  id: ExecutionId;
+  templateId: TemplateId;
+  parameters: CompetitorAnalysisParameters;
+  status: ExecutionStatus;
+  errorMessage?: string;
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  agentExecutions: AgentExecutionDetail[];
+  result?: ResultDetail;
+};

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -1,0 +1,202 @@
+/**
+ * ドメインモデルの型定義。
+ *
+ * SSoT: docs/design/data-model.md / docs/design/templates/competitor-analysis.md
+ * 命名規約は data-model.md §6 の TS 例に合わせて snake_case を採用する。
+ * REST/WS 境界での camelCase は api-types.ts / ws-types.ts 側で定義する。
+ */
+
+// ---------- 識別子 ----------
+// MVP では string のまま。branded type 化は将来検討（api-design.md §エラーレスポンス 注）。
+
+export type TemplateId = string;
+export type ExecutionId = string;
+export type AgentExecutionId = string;
+export type ResultId = string;
+
+// ---------- 共通 enum ----------
+
+/** AgentExecution / Execution の状態（data-model.md §5）。 */
+export type ExecutionStatus = "pending" | "running" | "completed" | "failed";
+export type AgentStatus = "pending" | "running" | "completed" | "failed";
+
+/** エージェントの役割（data-model.md §4.3）。 */
+export type AgentRole = "investigation" | "integration";
+
+/** 個別エージェントの失敗理由（agent-execution.md §5）。 */
+export type AgentFailReason =
+  | "llm_error"
+  | "output_parse_error"
+  | "timeout"
+  | "internal_error";
+
+/** Execution 全体の失敗理由（agent-execution.md §5）。 */
+export type ExecutionFailReason =
+  | "all_investigations_failed"
+  | "integration_failed"
+  | "timeout";
+
+// ---------- Template ----------
+
+/**
+ * Template.definition.input_schema の格納形式。
+ * JSON Schema を生のまま保持するため、本パッケージでは構造を強制しない。
+ */
+export type JsonSchema = Record<string, unknown>;
+
+/** LLM 既定値（data-model.md §6 / llm-integration.md が値の SSoT）。 */
+export type LlmDefaults = {
+  model: string;
+  temperature_by_role: { investigation: number; integration: number };
+  max_tokens_by_role: { investigation: number; integration: number };
+};
+
+/** Investigation Agent の静的定義（data-model.md §6）。 */
+export type InvestigationAgentDefinition = {
+  role: "investigation";
+  agent_id: string;
+  specialization: {
+    perspective_key: string;
+    perspective_name_ja: string;
+    perspective_description: string;
+  };
+  system_prompt_template: string;
+};
+
+/** Integration Agent の静的定義（data-model.md §6）。 */
+export type IntegrationAgentDefinition = {
+  role: "integration";
+  agent_id: string;
+  system_prompt_template: string;
+};
+
+/** テンプレート定義（agents は Investigation / Integration の混在）。 */
+export type AgentDefinition =
+  | InvestigationAgentDefinition
+  | IntegrationAgentDefinition;
+
+export type TemplateDefinition = {
+  schema_version: "1";
+  input_schema: JsonSchema;
+  agents: AgentDefinition[];
+  llm: LlmDefaults;
+};
+
+export type Template = {
+  id: TemplateId;
+  name: string;
+  description: string;
+  definition: TemplateDefinition;
+  created_at: string;
+  updated_at: string;
+};
+
+// ---------- Execution / AgentExecution / Result ----------
+
+export type Execution = {
+  id: ExecutionId;
+  template_id: TemplateId;
+  parameters: CompetitorAnalysisParameters;
+  status: ExecutionStatus;
+  error_message?: string;
+  created_at: string;
+  started_at?: string;
+  completed_at?: string;
+};
+
+/**
+ * AgentExecution は role により output 型が異なる discriminated union
+ * （data-model.md §8）。共通プロパティを generic で抽出する。
+ */
+type AgentExecutionBase<R extends AgentRole, O> = {
+  id: AgentExecutionId;
+  execution_id: ExecutionId;
+  agent_id: string;
+  role: R;
+  status: AgentStatus;
+  output?: O;
+  error_message?: string;
+  started_at?: string;
+  completed_at?: string;
+};
+
+export type InvestigationAgentExecution = AgentExecutionBase<
+  "investigation",
+  InvestigationAgentOutput
+>;
+
+export type IntegrationAgentExecution = AgentExecutionBase<
+  "integration",
+  IntegrationAgentOutput
+>;
+
+export type AgentExecution =
+  | InvestigationAgentExecution
+  | IntegrationAgentExecution;
+
+export type Result = {
+  id: ResultId;
+  execution_id: ExecutionId;
+  markdown: string;
+  structured: CompetitorAnalysisResult;
+  created_at: string;
+};
+
+// ---------- 競合調査テンプレート固有の I/O ----------
+// SSoT: docs/design/templates/competitor-analysis.md
+
+export type CompetitorPerspectiveKey =
+  | "strategy"
+  | "product"
+  | "investment"
+  | "partnership";
+
+export type EvidenceLevel = "strong" | "moderate" | "weak" | "insufficient";
+
+/** Execution.parameters（competitor-analysis.md §入力パラメータ JSON Schema）。 */
+export type CompetitorAnalysisParameters = {
+  competitors: string[];
+  reference?: string;
+};
+
+/** Investigation Agent の出力（competitor-analysis.md §Investigation Agent 出力）。 */
+export type InvestigationAgentOutput = {
+  perspective: CompetitorPerspectiveKey;
+  findings: InvestigationFinding[];
+};
+
+export type InvestigationFinding = {
+  competitor: string;
+  points: string[];
+  evidence_level: EvidenceLevel;
+  notes?: string;
+};
+
+/**
+ * Integration Agent の出力 = Result.structured と同型
+ * （competitor-analysis.md §Integration Agent 出力）。
+ */
+export type IntegrationAgentOutput = {
+  matrix: PerspectiveMatrixRow[];
+  overall_insights: string[];
+  missing: MissingPerspective[];
+};
+
+export type CompetitorAnalysisResult = IntegrationAgentOutput;
+
+export type PerspectiveMatrixRow = {
+  perspective: CompetitorPerspectiveKey;
+  cells: MatrixCell[];
+};
+
+export type MatrixCell = {
+  competitor: string;
+  summary: string;
+  /** Investigation Agent の evidence_level を転記（agent_failed は含まれない）。 */
+  source_evidence_level: EvidenceLevel;
+};
+
+export type MissingPerspective = {
+  perspective: CompetitorPerspectiveKey;
+  reason: "agent_failed" | "insufficient_evidence";
+};

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -96,6 +96,11 @@ export type Template = {
 export type Execution = {
   id: ExecutionId;
   template_id: TemplateId;
+  /**
+   * MVP はシードテンプレート（競合調査）1 件のみ（ADR-0005）のため、
+   * テンプレート固有型に直接依存させる。複数テンプレート対応時に
+   * generic 化または unknown + Zod バリデーションに切り替える。
+   */
   parameters: CompetitorAnalysisParameters;
   status: ExecutionStatus;
   error_message?: string;

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, test } from "bun:test";
-
-describe("shared", () => {
-  test("package is importable", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * 型のみ利用するコンシューマーでも barrel re-export 経由で `ws-guards.ts` の
+ * runtime コードが含まれる形になる。MVP では shared の利用者が限定的（apps/api,
+ * apps/web, packages/db, packages/agent-core）でツリーシェイキングが効くため許容する。
+ * 利用者が増えて runtime 混入が問題化した場合は `./types` / `./guards` の
+ * サブパス export に分割する。
+ */
 export * from "./api-types.ts";
 export * from "./domain-types.ts";
 export * from "./ws-guards.ts";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,4 @@
-export {};
+export * from "./api-types.ts";
+export * from "./domain-types.ts";
+export * from "./ws-guards.ts";
+export * from "./ws-types.ts";

--- a/packages/shared/src/ws-guards.test.ts
+++ b/packages/shared/src/ws-guards.test.ts
@@ -8,83 +8,146 @@ import {
 } from "./ws-guards.ts";
 import type { WsMessage } from "./ws-types.ts";
 
-const agentStatusRunning: WsMessage = {
+const agentStatusPendingMessage: WsMessage = {
+  type: "agent:status",
+  agentId: "investigation:strategy",
+  status: "pending",
+};
+
+const agentStatusRunningMessage: WsMessage = {
   type: "agent:status",
   agentId: "investigation:strategy",
   status: "running",
   timestamp: "2026-04-17T10:00:00Z",
 };
 
-const agentStatusFailed: WsMessage = {
+const agentStatusCompletedMessage: WsMessage = {
+  type: "agent:status",
+  agentId: "investigation:strategy",
+  status: "completed",
+  timestamp: "2026-04-17T10:00:30Z",
+};
+
+const agentStatusFailedMessage: WsMessage = {
   type: "agent:status",
   agentId: "investigation:strategy",
   status: "failed",
   reason: "llm_error",
-  timestamp: "2026-04-17T10:00:00Z",
+  timestamp: "2026-04-17T10:00:30Z",
 };
 
-const agentOutput: WsMessage = {
+const agentOutputMessage: WsMessage = {
   type: "agent:output",
   agentId: "investigation:strategy",
   chunk: "..",
 };
 
-const executionCompleted: WsMessage = {
+const executionCompletedMessage: WsMessage = {
   type: "execution:completed",
   executionId: "exec_1",
   resultId: "res_1",
 };
 
-const executionFailed: WsMessage = {
+const executionFailedMessage: WsMessage = {
   type: "execution:failed",
   executionId: "exec_1",
   reason: "all_investigations_failed",
 };
 
+/**
+ * union の全メンバーを列挙したリスト。
+ * 各ガードのネガティブテストで「対象以外の全メンバーが false になる」ことを
+ * 網羅検証するために共有する。新しい WsMessage バリアント追加時は本リストにも
+ * 1 件追加することで、既存ガードの網羅性が自動で維持される。
+ */
+const allMessages: WsMessage[] = [
+  agentStatusPendingMessage,
+  agentStatusRunningMessage,
+  agentStatusCompletedMessage,
+  agentStatusFailedMessage,
+  agentOutputMessage,
+  executionCompletedMessage,
+  executionFailedMessage,
+];
+
 describe("isAgentStatusMessage", () => {
-  test("agent:status を識別する", () => {
-    expect(isAgentStatusMessage(agentStatusRunning)).toBe(true);
-    expect(isAgentStatusMessage(agentStatusFailed)).toBe(true);
+  test("agent:status の全 4 バリアントを識別する", () => {
+    expect(isAgentStatusMessage(agentStatusPendingMessage)).toBe(true);
+    expect(isAgentStatusMessage(agentStatusRunningMessage)).toBe(true);
+    expect(isAgentStatusMessage(agentStatusCompletedMessage)).toBe(true);
+    expect(isAgentStatusMessage(agentStatusFailedMessage)).toBe(true);
   });
 
-  test("他の type は false", () => {
-    expect(isAgentStatusMessage(agentOutput)).toBe(false);
-    expect(isAgentStatusMessage(executionCompleted)).toBe(false);
-    expect(isAgentStatusMessage(executionFailed)).toBe(false);
+  test("agent:status 以外は全て false", () => {
+    const others = allMessages.filter((m) => m.type !== "agent:status");
+    for (const m of others) {
+      expect(isAgentStatusMessage(m)).toBe(false);
+    }
   });
 });
 
 describe("isAgentStatusFailed", () => {
   test("status=failed のみ true", () => {
-    expect(isAgentStatusFailed(agentStatusFailed)).toBe(true);
-    expect(isAgentStatusFailed(agentStatusRunning)).toBe(false);
+    expect(isAgentStatusFailed(agentStatusFailedMessage)).toBe(true);
+    expect(isAgentStatusFailed(agentStatusPendingMessage)).toBe(false);
+    expect(isAgentStatusFailed(agentStatusRunningMessage)).toBe(false);
+    expect(isAgentStatusFailed(agentStatusCompletedMessage)).toBe(false);
+  });
+
+  test("agent:status 以外は全て false", () => {
+    const others = allMessages.filter((m) => m.type !== "agent:status");
+    for (const m of others) {
+      expect(isAgentStatusFailed(m)).toBe(false);
+    }
   });
 
   test("ナローイング後に reason へ安全にアクセスできる", () => {
-    if (isAgentStatusFailed(agentStatusFailed)) {
-      // 型レベルで reason へアクセスできることを確認
-      expect(agentStatusFailed.reason).toBe("llm_error");
+    // ガードが true を返すこと自体を先行 assert で保証してから
+    // ナローイングのコンパイル時挙動を確認する（else を踏まないことを担保）。
+    expect(isAgentStatusFailed(agentStatusFailedMessage)).toBe(true);
+    if (isAgentStatusFailed(agentStatusFailedMessage)) {
+      expect(agentStatusFailedMessage.reason).toBe("llm_error");
+    } else {
+      throw new Error("到達不能: 先行 assert で true を保証している");
     }
   });
 });
 
 describe("isAgentOutputMessage", () => {
   test("agent:output を識別する", () => {
-    expect(isAgentOutputMessage(agentOutput)).toBe(true);
-    expect(isAgentOutputMessage(agentStatusRunning)).toBe(false);
+    expect(isAgentOutputMessage(agentOutputMessage)).toBe(true);
+  });
+
+  test("agent:output 以外は全て false", () => {
+    const others = allMessages.filter((m) => m.type !== "agent:output");
+    for (const m of others) {
+      expect(isAgentOutputMessage(m)).toBe(false);
+    }
   });
 });
 
 describe("isExecutionCompletedMessage", () => {
   test("execution:completed を識別する", () => {
-    expect(isExecutionCompletedMessage(executionCompleted)).toBe(true);
-    expect(isExecutionCompletedMessage(executionFailed)).toBe(false);
+    expect(isExecutionCompletedMessage(executionCompletedMessage)).toBe(true);
+  });
+
+  test("execution:completed 以外は全て false", () => {
+    const others = allMessages.filter((m) => m.type !== "execution:completed");
+    for (const m of others) {
+      expect(isExecutionCompletedMessage(m)).toBe(false);
+    }
   });
 });
 
 describe("isExecutionFailedMessage", () => {
   test("execution:failed を識別する", () => {
-    expect(isExecutionFailedMessage(executionFailed)).toBe(true);
-    expect(isExecutionFailedMessage(executionCompleted)).toBe(false);
+    expect(isExecutionFailedMessage(executionFailedMessage)).toBe(true);
+  });
+
+  test("execution:failed 以外は全て false", () => {
+    const others = allMessages.filter((m) => m.type !== "execution:failed");
+    for (const m of others) {
+      expect(isExecutionFailedMessage(m)).toBe(false);
+    }
   });
 });

--- a/packages/shared/src/ws-guards.test.ts
+++ b/packages/shared/src/ws-guards.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isAgentOutputMessage,
+  isAgentStatusFailed,
+  isAgentStatusMessage,
+  isExecutionCompletedMessage,
+  isExecutionFailedMessage,
+} from "./ws-guards.ts";
+import type { WsMessage } from "./ws-types.ts";
+
+const agentStatusRunning: WsMessage = {
+  type: "agent:status",
+  agentId: "investigation:strategy",
+  status: "running",
+  timestamp: "2026-04-17T10:00:00Z",
+};
+
+const agentStatusFailed: WsMessage = {
+  type: "agent:status",
+  agentId: "investigation:strategy",
+  status: "failed",
+  reason: "llm_error",
+  timestamp: "2026-04-17T10:00:00Z",
+};
+
+const agentOutput: WsMessage = {
+  type: "agent:output",
+  agentId: "investigation:strategy",
+  chunk: "..",
+};
+
+const executionCompleted: WsMessage = {
+  type: "execution:completed",
+  executionId: "exec_1",
+  resultId: "res_1",
+};
+
+const executionFailed: WsMessage = {
+  type: "execution:failed",
+  executionId: "exec_1",
+  reason: "all_investigations_failed",
+};
+
+describe("isAgentStatusMessage", () => {
+  test("agent:status を識別する", () => {
+    expect(isAgentStatusMessage(agentStatusRunning)).toBe(true);
+    expect(isAgentStatusMessage(agentStatusFailed)).toBe(true);
+  });
+
+  test("他の type は false", () => {
+    expect(isAgentStatusMessage(agentOutput)).toBe(false);
+    expect(isAgentStatusMessage(executionCompleted)).toBe(false);
+    expect(isAgentStatusMessage(executionFailed)).toBe(false);
+  });
+});
+
+describe("isAgentStatusFailed", () => {
+  test("status=failed のみ true", () => {
+    expect(isAgentStatusFailed(agentStatusFailed)).toBe(true);
+    expect(isAgentStatusFailed(agentStatusRunning)).toBe(false);
+  });
+
+  test("ナローイング後に reason へ安全にアクセスできる", () => {
+    if (isAgentStatusFailed(agentStatusFailed)) {
+      // 型レベルで reason へアクセスできることを確認
+      expect(agentStatusFailed.reason).toBe("llm_error");
+    }
+  });
+});
+
+describe("isAgentOutputMessage", () => {
+  test("agent:output を識別する", () => {
+    expect(isAgentOutputMessage(agentOutput)).toBe(true);
+    expect(isAgentOutputMessage(agentStatusRunning)).toBe(false);
+  });
+});
+
+describe("isExecutionCompletedMessage", () => {
+  test("execution:completed を識別する", () => {
+    expect(isExecutionCompletedMessage(executionCompleted)).toBe(true);
+    expect(isExecutionCompletedMessage(executionFailed)).toBe(false);
+  });
+});
+
+describe("isExecutionFailedMessage", () => {
+  test("execution:failed を識別する", () => {
+    expect(isExecutionFailedMessage(executionFailed)).toBe(true);
+    expect(isExecutionFailedMessage(executionCompleted)).toBe(false);
+  });
+});

--- a/packages/shared/src/ws-guards.ts
+++ b/packages/shared/src/ws-guards.ts
@@ -3,6 +3,10 @@
  *
  * `WsMessage` discriminated union から特定バリアントへナローイングするための
  * 最小限のヘルパー。本ファイルは runtime コードを含むため ws-types.ts とは分離する。
+ *
+ * 受信した生データ（unknown）を `WsMessage` にする parse / 検証は WS ハンドラ層
+ * （apps/api 側）の責務とし、本ファイルは parse 済みの `WsMessage` に対する
+ * バリアント識別のみを担う。Zod 等のスキーマ検証はコンシューマー側で行う。
  */
 
 import type {

--- a/packages/shared/src/ws-guards.ts
+++ b/packages/shared/src/ws-guards.ts
@@ -1,0 +1,45 @@
+/**
+ * WebSocket メッセージの型ガード関数。
+ *
+ * `WsMessage` discriminated union から特定バリアントへナローイングするための
+ * 最小限のヘルパー。本ファイルは runtime コードを含むため ws-types.ts とは分離する。
+ */
+
+import type {
+  AgentOutputMessage,
+  AgentStatusFailedMessage,
+  AgentStatusMessage,
+  ExecutionCompletedMessage,
+  ExecutionFailedMessage,
+  WsMessage,
+} from "./ws-types.ts";
+
+export function isAgentStatusMessage(
+  msg: WsMessage,
+): msg is AgentStatusMessage {
+  return msg.type === "agent:status";
+}
+
+export function isAgentStatusFailed(
+  msg: WsMessage,
+): msg is AgentStatusFailedMessage {
+  return msg.type === "agent:status" && msg.status === "failed";
+}
+
+export function isAgentOutputMessage(
+  msg: WsMessage,
+): msg is AgentOutputMessage {
+  return msg.type === "agent:output";
+}
+
+export function isExecutionCompletedMessage(
+  msg: WsMessage,
+): msg is ExecutionCompletedMessage {
+  return msg.type === "execution:completed";
+}
+
+export function isExecutionFailedMessage(
+  msg: WsMessage,
+): msg is ExecutionFailedMessage {
+  return msg.type === "execution:failed";
+}

--- a/packages/shared/src/ws-types.ts
+++ b/packages/shared/src/ws-types.ts
@@ -1,0 +1,86 @@
+/**
+ * WebSocket メッセージの型定義（サーバ → クライアント）。
+ *
+ * SSoT: docs/design/websocket-design.md
+ * 命名規約は同 doc の JSON 例に合わせて camelCase。
+ *
+ * 設計 doc では `agent:status` の `reason?` を任意としていたが、
+ * 型安全性のため `status: "failed"` を専用バリアント `AgentStatusFailedMessage` に
+ * 分離して `reason` を必須にしている（websocket-design.md §メッセージ型 末尾の方針）。
+ */
+
+import type {
+  AgentFailReason,
+  ExecutionFailReason,
+  ExecutionId,
+  ResultId,
+} from "./domain-types.ts";
+
+// ---------- agent:status ----------
+
+type AgentStatusBase = {
+  type: "agent:status";
+  agentId: string;
+  /** ISO 8601。発火時刻（agent_started / agent_completed / agent_failed）を集約。 */
+  timestamp: string;
+};
+
+/**
+ * 初期スナップショット時のみ送信される（websocket-design.md §接続ライフサイクル）。
+ * 対応する AgentEvent は存在しない。
+ */
+export type AgentStatusPendingMessage = AgentStatusBase & {
+  status: "pending";
+};
+
+export type AgentStatusRunningMessage = AgentStatusBase & {
+  status: "running";
+};
+
+export type AgentStatusCompletedMessage = AgentStatusBase & {
+  status: "completed";
+};
+
+export type AgentStatusFailedMessage = AgentStatusBase & {
+  status: "failed";
+  reason: AgentFailReason;
+};
+
+export type AgentStatusMessage =
+  | AgentStatusPendingMessage
+  | AgentStatusRunningMessage
+  | AgentStatusCompletedMessage
+  | AgentStatusFailedMessage;
+
+// ---------- agent:output ----------
+
+export type AgentOutputMessage = {
+  type: "agent:output";
+  agentId: string;
+  chunk: string;
+};
+
+// ---------- execution:completed / execution:failed ----------
+
+export type ExecutionCompletedMessage = {
+  type: "execution:completed";
+  executionId: ExecutionId;
+  resultId: ResultId;
+};
+
+export type ExecutionFailedMessage = {
+  type: "execution:failed";
+  executionId: ExecutionId;
+  reason: ExecutionFailReason;
+};
+
+// ---------- WS メッセージ全体 ----------
+
+export type WsMessage =
+  | AgentStatusMessage
+  | AgentOutputMessage
+  | ExecutionCompletedMessage
+  | ExecutionFailedMessage;
+
+/** WS メッセージの種別文字列（websocket-design.md §メッセージ型 の `type` フィールド）。 */
+export type WsMessageType = WsMessage["type"];

--- a/packages/shared/src/ws-types.ts
+++ b/packages/shared/src/ws-types.ts
@@ -21,30 +21,42 @@ import type {
 type AgentStatusBase = {
   type: "agent:status";
   agentId: string;
-  /** ISO 8601。発火時刻（agent_started / agent_completed / agent_failed）を集約。 */
+};
+
+/**
+ * timestamp 付きバリアント用の追加プロパティ。
+ * websocket-design.md §AgentEvent → WsMessage 写像 に従い
+ * agent_started / agent_completed / agent_failed の発火時刻を集約する。
+ */
+type WithEventTimestamp = {
+  /** ISO 8601。 */
   timestamp: string;
 };
 
 /**
  * 初期スナップショット時のみ送信される（websocket-design.md §接続ライフサイクル）。
- * 対応する AgentEvent は存在しない。
+ * 対応する AgentEvent は存在せず、pending 時点では started_at が DB に未 INSERT のため
+ * timestamp は持たない。
  */
 export type AgentStatusPendingMessage = AgentStatusBase & {
   status: "pending";
 };
 
-export type AgentStatusRunningMessage = AgentStatusBase & {
-  status: "running";
-};
+export type AgentStatusRunningMessage = AgentStatusBase &
+  WithEventTimestamp & {
+    status: "running";
+  };
 
-export type AgentStatusCompletedMessage = AgentStatusBase & {
-  status: "completed";
-};
+export type AgentStatusCompletedMessage = AgentStatusBase &
+  WithEventTimestamp & {
+    status: "completed";
+  };
 
-export type AgentStatusFailedMessage = AgentStatusBase & {
-  status: "failed";
-  reason: AgentFailReason;
-};
+export type AgentStatusFailedMessage = AgentStatusBase &
+  WithEventTimestamp & {
+    status: "failed";
+    reason: AgentFailReason;
+  };
 
 export type AgentStatusMessage =
   | AgentStatusPendingMessage


### PR DESCRIPTION
## What

`packages/shared` を「型の Single Source of Truth」として実コード化。設計ドキュメントにある型定義を TypeScript 実装として移植した。

- `domain-types.ts` — Template / Execution / AgentExecution / Result + 競合調査テンプレートの I/O 型（`data-model.md`, `templates/competitor-analysis.md` 準拠、snake_case）
- `api-types.ts` — REST リクエスト/レスポンス + `ApiError` discriminated union（`api-design.md` 準拠、camelCase）
- `ws-types.ts` — `WsMessage` discriminated union（`websocket-design.md` 準拠、camelCase）
- `ws-guards.ts` — `WsMessage` の型ガード関数 5 つ
- `ws-guards.test.ts` — 型ガードの振る舞いテスト（旧ダミー `index.test.ts` を置換）
- `index.ts` — 上記 4 ファイルの barrel re-export

## Why

closes #79

ADR-0010「型駆動 + 軽量 TDD」の前提として、後続 Issue（#78 DB schema / #82 Walking Skeleton / US-1〜）が参照する型 SSoT を MVP 実装着手前に揃えるため。

## How

### 設計判断

- **命名規約の使い分け**: 設計 doc と 1:1 対応するため、domain は snake_case（data-model.md §6 の TS 例準拠）、api/ws は camelCase（各 doc の JSON 例準拠）
- **`agent:status status="failed"` を専用バリアントに分離**: websocket-design.md §メッセージ型 末尾の方針に従い、`AgentStatusFailedMessage` で `reason` を必須化
- **ID は string のまま**: api-design.md 注「将来 branded type 化を検討」と整合
- **型ガードを別ファイル**: 純粋型ファイル（型のみ）と runtime コードの責務分離
- **zod schema は同梱しない**: 入力バリデーションは API ハンドラ層で行う想定（api-design.md §`errorCode` と整合）

### コミット粒度

3 コミットに分割:

1. `9d47c0c` ドメインモデル型
2. `88937c1` REST API 型
3. `53177d7` WS メッセージ型 + 型ガード + テスト + index 整備

## Checklist

- [x] `bun run lint` 緑（biome / markdownlint / secretlint）
- [x] `bun run type-check` 緑（5 workspace）
- [x] `bun run test` 緑（7 pass / 0 fail）
- [x] `bun run build` 緑
- [x] 後続 Issue から `@agent-team-studio/shared` として import 可能（barrel export 済み）