### PR TITLE
feat(db): MVP データモデルの Drizzle schema + migration + seed 整備 #78

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
         "pg": "^8.20.0",
       },
       "devDependencies": {
+        "@types/node": "^25.6.0",
         "@types/pg": "^8.20.0",
         "drizzle-kit": "^0.31.10",
       },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,3 +46,10 @@ volumes:
     # サービス定義内の論理参照名は pgdata 固定だが、外部 volume 名（Docker が管理する実名）は
     # DB_VOLUME で動的に切替する（worktree 単位の DB 隔離用）
     name: ${DB_VOLUME:?env_required}
+
+networks:
+  # compose のデフォルトネットワーク名を明示する。
+  # DevContainer の起動経路や compose project 名の再生成（ADR-0018）の影響で
+  # app と db が別ネットワークに分離する事故を避けるためのガードレール。
+  default:
+    name: agent-team-studio

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "type-check": "turbo run type-check",
     "test": "turbo run test",
     "build": "turbo run build",
+    "db:generate": "turbo run db:generate",
+    "db:migrate": "turbo run db:migrate",
+    "db:seed": "turbo run db:seed",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,127 @@
+# @agent-team-studio/db
+
+MVP のデータ永続化レイヤー。Drizzle ORM + PostgreSQL（[ADR-0008](../../docs/adr/0008-tech-stack.md)）。
+
+論理モデルの SSoT は [docs/design/data-model.md](../../docs/design/data-model.md)。本 README は **物理スキーマ規約**（命名・ID 形式・制約・テスト戦略）の SSoT。
+
+## ディレクトリ構成
+
+```text
+packages/db/
+├── drizzle.config.ts          # drizzle-kit 設定
+├── drizzle/migrations/        # 生成される migration SQL（手動編集しない）
+└── src/
+    ├── schema/                # 物理スキーマ（テーブル定義）
+    │   ├── templates.ts
+    │   ├── executions.ts
+    │   ├── agent-executions.ts
+    │   ├── results.ts
+    │   └── index.ts
+    ├── seed-data/             # シード用データ定義
+    │   └── competitor-analysis.ts
+    ├── client.ts              # DbClient ファクトリ
+    ├── migrate.ts             # `bun run db:migrate` の実体
+    ├── seed.ts                # `bun run db:seed` の実体
+    └── index.ts               # パッケージエントリ
+```
+
+## コマンド
+
+ルートで実行する（turbo 経由）:
+
+| コマンド | 用途 |
+| --- | --- |
+| `bun run db:generate` | schema 差分から migration SQL を生成 |
+| `bun run db:migrate` | 生成済み SQL を `DATABASE_URL` の DB に適用 |
+| `bun run db:seed` | 競合調査テンプレートを投入（冪等） |
+
+`DATABASE_URL` は compose の env 経由で注入される（[ADR-0018](../../docs/adr/0018-relocate-compose-and-consolidate-env.md)）。turbo 側で `env: ["DATABASE_URL"]` を明示しているので、env を変えると task キャッシュが正しく無効化される（本タスクは `cache: false` だが将来の保険）。
+
+## 物理スキーマ規約
+
+### ID 形式
+
+- **UUID v7**（PostgreSQL 18 ネイティブの `uuidv7()` で DB 側生成）
+- 全テーブルで `id uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL`
+- 採用理由: ① RFC 9562 標準 ② 時系列ソート可能（先頭 48bit が ms タイムスタンプ） ③ PG 18 でネイティブ関数として標準化済み
+- アプリ側生成は不要（DB に任せる）
+
+### カラム命名
+
+- DB カラム: `snake_case`（`created_at`, `template_id` など）
+- TS フィールド: `camelCase`（Drizzle が自動マッピング、`drizzle.config.ts` で `casing: "snake_case"` を有効化）
+- domain-types.ts の論理モデルは `snake_case`（[data-model.md §6](../../docs/design/data-model.md) と整合）。Drizzle の `$inferSelect` は camelCase に変換されるため、repo 層での明示マッピングは不要
+
+### enum の表現
+
+- **`text` カラム + `CHECK` 制約** で表現（PG enum 型は使わない）
+- 採用理由: 値追加・削除が `ALTER TABLE ... ADD/DROP CONSTRAINT` で済むため、MVP の変動期に強い
+- TS 側型安全は Drizzle の `text("col", { enum: [...] })` で確保
+- DB 側防護壁は `pgTable` の third arg で `check()` を明示（二重）
+
+### timestamp
+
+- 全 timestamp は `timestamp with time zone`（`timestamptz`）
+- DB 既定値は `defaultNow()`（PG 側 `now()` で生成。アプリ起動時刻に依存しない）
+
+### FK ポリシー
+
+| 関係 | onDelete | 理由 |
+| --- | --- | --- |
+| `executions.template_id` → `templates.id` | `RESTRICT` | テンプレ消失で過去実行が宙吊りにならないよう保護 |
+| `agent_executions.execution_id` → `executions.id` | `CASCADE` | 親 Execution 削除時に追従（独立保持の必要なし） |
+| `results.execution_id` → `executions.id` | `CASCADE` | 同上 |
+
+### UNIQUE 制約
+
+| 制約 | 施行場所 | 由来 |
+| --- | --- | --- |
+| `(execution_id, agent_id)` UNIQUE on `agent_executions` | DB UNIQUE INDEX | [data-model.md §3](../../docs/design/data-model.md) 不変条件「同一 Execution 内で agent_id は一意」 |
+| `(execution_id)` UNIQUE on `results` | DB UNIQUE INDEX | [data-model.md §2](../../docs/design/data-model.md) `Execution : Result = 1 : 0..1` |
+
+### JSON カラム
+
+- 全構造化属性は `jsonb`（`json` ではない。PG ネイティブの構造化検索とインデックスを活かすため）
+- Drizzle の `.$type<T>()` で TS 型を伝搬。ランタイムバリデーションは別途必要（書き込み時に zod 等を検討）
+
+## seed データ
+
+`bun run db:seed` で競合調査テンプレートを 1 件投入する。
+
+- 名前 `競合調査` で既存チェック → 既存ならスキップ（冪等）
+- 投入内容の SSoT: `src/seed-data/competitor-analysis.ts`
+  - `input_schema`: [docs/design/templates/competitor-analysis.md](../../docs/design/templates/competitor-analysis.md)
+  - `system_prompt_template`: [docs/product/templates/competitor-analysis.md](../../docs/product/templates/competitor-analysis.md)
+  - `LlmDefaults`: [docs/design/llm-integration.md](../../docs/design/llm-integration.md)
+  - `agent_id`: A4（[Issue #53](https://github.com/kuairen-227/agent-team-studio/issues/53)）で命名規約確定後に更新
+
+## テスト用 DB 戦略
+
+MVP は **truncate-per-test** を採用する。
+
+- 各テストの `beforeEach` で全テーブルを `TRUNCATE ... CASCADE`
+- 並列実行は当面想定しない（テスト数が少ないうち）
+- 設定は最小限。テストフィクスチャ配置方針は Walking Skeleton（[Issue #82](https://github.com/kuairen-227/agent-team-studio/issues/82)）の R1 で `docs/guides/development-workflow.md` に追記
+
+将来の拡張パス（必要になった時点で切替）:
+
+| 戦略 | 移行条件 |
+| --- | --- |
+| transaction rollback | テストごとの実行時間を更に圧縮したくなった |
+| schema 分離 | テスト並列化が必要（テスト本数が数百を超える） |
+| testcontainers | production-like 検証が必要 |
+
+## 後続 Issue で確定する事項
+
+| 項目 | 確定先 |
+| --- | --- |
+| `agent_id` 命名規約の最終形 | [Issue #53](https://github.com/kuairen-227/agent-team-studio/issues/53)（A4） |
+| LLM クライアント差し替え方針 | 最初の agent-core Issue |
+| `Result.structured` フィールド名の最終確認 | 実装で違和感が出たタイミングで再検討 |
+
+## 関連
+
+- [ADR-0008](../../docs/adr/0008-tech-stack.md) 技術スタック
+- [ADR-0009](../../docs/adr/0009-architecture.md) アーキテクチャ
+- [ADR-0014](../../docs/adr/0014-mvp-data-model-design.md) MVP データモデル設計方針
+- [docs/design/data-model.md](../../docs/design/data-model.md) 論理モデル SSoT

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,0 +1,32 @@
+/**
+ * drizzle-kit 設定。
+ *
+ * - schema: src/schema/ 配下のすべてのテーブル定義を集約
+ * - migration 出力先: drizzle/migrations
+ * - DATABASE_URL は env から読み取る（compose が app コンテナに注入する前提。ADR-0018）
+ *
+ * 実行コマンド:
+ * - bun run db:generate  ... schema 差分から SQL を生成
+ * - bun run db:migrate   ... 生成済み SQL を DB に適用
+ */
+
+import { defineConfig } from "drizzle-kit";
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+export default defineConfig({
+  schema: "./src/schema/index.ts",
+  out: "./drizzle/migrations",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: databaseUrl,
+  },
+  // 命名規約: snake_case（packages/db/README.md SSoT）
+  casing: "snake_case",
+  // 開発中は厳密モード（migration を未生成のまま push しない）
+  strict: true,
+  verbose: true,
+});

--- a/packages/db/drizzle/migrations/0000_complex_gamora.sql
+++ b/packages/db/drizzle/migrations/0000_complex_gamora.sql
@@ -6,10 +6,13 @@ CREATE TABLE "agent_executions" (
 	"status" text NOT NULL,
 	"output" jsonb,
 	"error_message" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"started_at" timestamp with time zone,
 	"completed_at" timestamp with time zone,
 	CONSTRAINT "agent_executions_role_check" CHECK ("agent_executions"."role" IN ('investigation', 'integration')),
-	CONSTRAINT "agent_executions_status_check" CHECK ("agent_executions"."status" IN ('pending', 'running', 'completed', 'failed'))
+	CONSTRAINT "agent_executions_status_check" CHECK ("agent_executions"."status" IN ('pending', 'running', 'completed', 'failed')),
+	CONSTRAINT "agent_executions_completed_requires_started_check" CHECK ("agent_executions"."completed_at" IS NULL OR "agent_executions"."started_at" IS NOT NULL),
+	CONSTRAINT "agent_executions_completed_after_started_check" CHECK ("agent_executions"."started_at" IS NULL OR "agent_executions"."completed_at" IS NULL OR "agent_executions"."completed_at" >= "agent_executions"."started_at")
 );
 --> statement-breakpoint
 CREATE TABLE "executions" (
@@ -21,7 +24,9 @@ CREATE TABLE "executions" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"started_at" timestamp with time zone,
 	"completed_at" timestamp with time zone,
-	CONSTRAINT "executions_status_check" CHECK ("executions"."status" IN ('pending', 'running', 'completed', 'failed'))
+	CONSTRAINT "executions_status_check" CHECK ("executions"."status" IN ('pending', 'running', 'completed', 'failed')),
+	CONSTRAINT "executions_completed_requires_started_check" CHECK ("executions"."completed_at" IS NULL OR "executions"."started_at" IS NOT NULL),
+	CONSTRAINT "executions_completed_after_started_check" CHECK ("executions"."started_at" IS NULL OR "executions"."completed_at" IS NULL OR "executions"."completed_at" >= "executions"."started_at")
 );
 --> statement-breakpoint
 CREATE TABLE "results" (

--- a/packages/db/drizzle/migrations/0000_sparkling_lilandra.sql
+++ b/packages/db/drizzle/migrations/0000_sparkling_lilandra.sql
@@ -1,0 +1,48 @@
+CREATE TABLE "agent_executions" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"execution_id" uuid NOT NULL,
+	"agent_id" text NOT NULL,
+	"role" text NOT NULL,
+	"status" text NOT NULL,
+	"output" jsonb,
+	"error_message" text,
+	"started_at" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	CONSTRAINT "agent_executions_role_check" CHECK ("agent_executions"."role" IN ('investigation', 'integration')),
+	CONSTRAINT "agent_executions_status_check" CHECK ("agent_executions"."status" IN ('pending', 'running', 'completed', 'failed'))
+);
+--> statement-breakpoint
+CREATE TABLE "executions" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"template_id" uuid NOT NULL,
+	"parameters" jsonb NOT NULL,
+	"status" text NOT NULL,
+	"error_message" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"started_at" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	CONSTRAINT "executions_status_check" CHECK ("executions"."status" IN ('pending', 'running', 'completed', 'failed'))
+);
+--> statement-breakpoint
+CREATE TABLE "results" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"execution_id" uuid NOT NULL,
+	"markdown" text NOT NULL,
+	"structured" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "templates" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"definition" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "agent_executions" ADD CONSTRAINT "agent_executions_execution_id_executions_id_fk" FOREIGN KEY ("execution_id") REFERENCES "public"."executions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "executions" ADD CONSTRAINT "executions_template_id_templates_id_fk" FOREIGN KEY ("template_id") REFERENCES "public"."templates"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "results" ADD CONSTRAINT "results_execution_id_executions_id_fk" FOREIGN KEY ("execution_id") REFERENCES "public"."executions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "agent_executions_execution_agent_unique" ON "agent_executions" USING btree ("execution_id","agent_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "results_execution_unique" ON "results" USING btree ("execution_id");

--- a/packages/db/drizzle/migrations/meta/0000_snapshot.json
+++ b/packages/db/drizzle/migrations/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "6f9a8491-02f0-432b-a79c-7181064b1428",
+  "id": "07ade821-1233-4c8c-980c-20cf32d24fd2",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -50,6 +50,13 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
         },
         "started_at": {
           "name": "started_at",
@@ -113,6 +120,14 @@
         "agent_executions_status_check": {
           "name": "agent_executions_status_check",
           "value": "\"agent_executions\".\"status\" IN ('pending', 'running', 'completed', 'failed')"
+        },
+        "agent_executions_completed_requires_started_check": {
+          "name": "agent_executions_completed_requires_started_check",
+          "value": "\"agent_executions\".\"completed_at\" IS NULL OR \"agent_executions\".\"started_at\" IS NOT NULL"
+        },
+        "agent_executions_completed_after_started_check": {
+          "name": "agent_executions_completed_after_started_check",
+          "value": "\"agent_executions\".\"started_at\" IS NULL OR \"agent_executions\".\"completed_at\" IS NULL OR \"agent_executions\".\"completed_at\" >= \"agent_executions\".\"started_at\""
         }
       },
       "isRLSEnabled": false
@@ -195,6 +210,14 @@
         "executions_status_check": {
           "name": "executions_status_check",
           "value": "\"executions\".\"status\" IN ('pending', 'running', 'completed', 'failed')"
+        },
+        "executions_completed_requires_started_check": {
+          "name": "executions_completed_requires_started_check",
+          "value": "\"executions\".\"completed_at\" IS NULL OR \"executions\".\"started_at\" IS NOT NULL"
+        },
+        "executions_completed_after_started_check": {
+          "name": "executions_completed_after_started_check",
+          "value": "\"executions\".\"started_at\" IS NULL OR \"executions\".\"completed_at\" IS NULL OR \"executions\".\"completed_at\" >= \"executions\".\"started_at\""
         }
       },
       "isRLSEnabled": false

--- a/packages/db/drizzle/migrations/meta/0000_snapshot.json
+++ b/packages/db/drizzle/migrations/meta/0000_snapshot.json
@@ -1,0 +1,341 @@
+{
+  "id": "6f9a8491-02f0-432b-a79c-7181064b1428",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_executions": {
+      "name": "agent_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_executions_execution_agent_unique": {
+          "name": "agent_executions_execution_agent_unique",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_executions_execution_id_executions_id_fk": {
+          "name": "agent_executions_execution_id_executions_id_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_executions_role_check": {
+          "name": "agent_executions_role_check",
+          "value": "\"agent_executions\".\"role\" IN ('investigation', 'integration')"
+        },
+        "agent_executions_status_check": {
+          "name": "agent_executions_status_check",
+          "value": "\"agent_executions\".\"status\" IN ('pending', 'running', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.executions": {
+      "name": "executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "executions_template_id_templates_id_fk": {
+          "name": "executions_template_id_templates_id_fk",
+          "tableFrom": "executions",
+          "tableTo": "templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "executions_status_check": {
+          "name": "executions_status_check",
+          "value": "\"executions\".\"status\" IN ('pending', 'running', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.results": {
+      "name": "results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structured": {
+          "name": "structured",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "results_execution_unique": {
+          "name": "results_execution_unique",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "results_execution_id_executions_id_fk": {
+          "name": "results_execution_id_executions_id_fk",
+          "tableFrom": "results",
+          "tableTo": "executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1777646545016,
-      "tag": "0000_sparkling_lilandra",
+      "when": 1777652335802,
+      "tag": "0000_complex_gamora",
       "breakpoints": true
     }
   ]

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1777646545016,
+      "tag": "0000_sparkling_lilandra",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,7 +8,10 @@
   },
   "scripts": {
     "lint": "biome check src/",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "bun run src/migrate.ts",
+    "db:seed": "bun run src/seed.ts"
   },
   "dependencies": {
     "@agent-team-studio/shared": "workspace:*",
@@ -16,6 +19,7 @@
     "pg": "^8.20.0"
   },
   "devDependencies": {
+    "@types/node": "^25.6.0",
     "@types/pg": "^8.20.0",
     "drizzle-kit": "^0.31.10"
   }

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,18 @@
+/**
+ * Drizzle DB クライアントのファクトリ。
+ *
+ * - drizzle-orm/node-postgres + pg を使う（drizzle driver は pg で確定）
+ * - DATABASE_URL は呼び出し側（apps/api / scripts）で env から取り出して渡す
+ *   → packages/db は env を直接読まない（テスト容易性・依存方向の単純化）
+ */
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import * as schema from "./schema/index.ts";
+
+export type DbClient = ReturnType<typeof createDbClient>;
+
+export function createDbClient(databaseUrl: string) {
+  const pool = new Pool({ connectionString: databaseUrl });
+  return drizzle(pool, { schema });
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -7,14 +7,18 @@
  *
  * close ハンドル付きで返す。テストや短命スクリプトで pool.end() を確実に呼べないと
  * プロセスがハングするため、戻り値経由でクローズ手段を露出する。
+ *
+ * `DrizzleDb` 型を export し、repo 層・seed 関数等で「db のみを受け取る」関数の引数型として使える。
  */
 
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as schema from "./schema/index.ts";
 
+export type DrizzleDb = ReturnType<typeof buildDb>;
+
 export type DbClient = {
-  db: ReturnType<typeof buildDb>;
+  db: DrizzleDb;
   close: () => Promise<void>;
 };
 

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -4,15 +4,28 @@
  * - drizzle-orm/node-postgres + pg を使う（drizzle driver は pg で確定）
  * - DATABASE_URL は呼び出し側（apps/api / scripts）で env から取り出して渡す
  *   → packages/db は env を直接読まない（テスト容易性・依存方向の単純化）
+ *
+ * close ハンドル付きで返す。テストや短命スクリプトで pool.end() を確実に呼べないと
+ * プロセスがハングするため、戻り値経由でクローズ手段を露出する。
  */
 
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as schema from "./schema/index.ts";
 
-export type DbClient = ReturnType<typeof createDbClient>;
+export type DbClient = {
+  db: ReturnType<typeof buildDb>;
+  close: () => Promise<void>;
+};
 
-export function createDbClient(databaseUrl: string) {
-  const pool = new Pool({ connectionString: databaseUrl });
+function buildDb(pool: Pool) {
   return drizzle(pool, { schema });
+}
+
+export function createDbClient(databaseUrl: string): DbClient {
+  const pool = new Pool({ connectionString: databaseUrl });
+  return {
+    db: buildDb(pool),
+    close: () => pool.end(),
+  };
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,5 +5,5 @@
  * - client: DB 接続（drizzle インスタンス）
  */
 
-export { createDbClient, type DbClient } from "./client.ts";
+export { createDbClient, type DbClient, type DrizzleDb } from "./client.ts";
 export * as schema from "./schema/index.ts";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,1 +1,9 @@
-export {};
+/**
+ * @agent-team-studio/db のエントリポイント。
+ *
+ * - schema: 全テーブル・enum 定数・行型
+ * - client: DB 接続（drizzle インスタンス）
+ */
+
+export { createDbClient, type DbClient } from "./client.ts";
+export * as schema from "./schema/index.ts";

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -6,23 +6,26 @@
  *
  * - 専用接続を使い、終了後に Pool を必ず閉じる（プロセスがハングしない）
  * - 適用済み migration は drizzle 内部の `__drizzle_migrations` テーブルで管理される
+ * - CLI 実行時のみ副作用を発生させるため `import.meta.main` ガードで保護する
+ *   （seed.ts と同じパターン。誤 import 時の意図しない migration 実行を防ぐ）
  */
 
 import { drizzle } from "drizzle-orm/node-postgres";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 import { Pool } from "pg";
 
-const databaseUrl = process.env.DATABASE_URL;
-if (!databaseUrl) {
-  throw new Error("DATABASE_URL is not set");
-}
+if (import.meta.main) {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not set");
+  }
 
-const pool = new Pool({ connectionString: databaseUrl });
-
-try {
-  const db = drizzle(pool);
-  await migrate(db, { migrationsFolder: "./drizzle/migrations" });
-  console.log("migrations applied");
-} finally {
-  await pool.end();
+  const pool = new Pool({ connectionString: databaseUrl });
+  try {
+    const db = drizzle(pool);
+    await migrate(db, { migrationsFolder: "./drizzle/migrations" });
+    console.log("migrations applied");
+  } finally {
+    await pool.end();
+  }
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -20,6 +20,7 @@ if (import.meta.main) {
     throw new Error("DATABASE_URL is not set");
   }
 
+  // migrate には schema バインドが不要なため createDbClient を経由せず Pool を直接使う
   const pool = new Pool({ connectionString: databaseUrl });
   try {
     const db = drizzle(pool);

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,0 +1,28 @@
+/**
+ * migration 適用スクリプト。
+ *
+ * `bun run db:migrate` の実体。drizzle-kit generate で生成された SQL を
+ * DATABASE_URL の DB に順番に適用する。
+ *
+ * - 専用接続を使い、終了後に Pool を必ず閉じる（プロセスがハングしない）
+ * - 適用済み migration は drizzle 内部の `__drizzle_migrations` テーブルで管理される
+ */
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { Pool } from "pg";
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+const pool = new Pool({ connectionString: databaseUrl });
+
+try {
+  const db = drizzle(pool);
+  await migrate(db, { migrationsFolder: "./drizzle/migrations" });
+  console.log("migrations applied");
+} finally {
+  await pool.end();
+}

--- a/packages/db/src/schema/agent-executions.ts
+++ b/packages/db/src/schema/agent-executions.ts
@@ -1,0 +1,73 @@
+/**
+ * `agent_executions` テーブル: Execution 内の個別エージェント実行。
+ *
+ * SSoT: docs/design/data-model.md §4.3, §5.1
+ *
+ * 物理スキーマの判断:
+ * - role / status は text + CHECK
+ * - output: jsonb（role により Investigation/Integration の discriminated union。
+ *   DB レベルでの分岐検証は行わず、TS 側型で担保）
+ * - UNIQUE (execution_id, agent_id): data-model.md §3 不変条件「同一 Execution 内で agent_id は一意」を DB で施行
+ * - 親 Execution への FK は ON DELETE CASCADE（Execution 削除時に追従）
+ */
+
+import type {
+  IntegrationAgentOutput,
+  InvestigationAgentOutput,
+} from "@agent-team-studio/shared";
+import { sql } from "drizzle-orm";
+import {
+  check,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { executions } from "./executions.ts";
+
+export const AGENT_ROLES = ["investigation", "integration"] as const;
+
+export const AGENT_STATUSES = [
+  "pending",
+  "running",
+  "completed",
+  "failed",
+] as const;
+
+export const agentExecutions = pgTable(
+  "agent_executions",
+  {
+    id: uuid("id").primaryKey().default(sql`uuidv7()`),
+    executionId: uuid("execution_id")
+      .notNull()
+      .references(() => executions.id, { onDelete: "cascade" }),
+    agentId: text("agent_id").notNull(),
+    role: text("role", { enum: AGENT_ROLES }).notNull(),
+    status: text("status", { enum: AGENT_STATUSES }).notNull(),
+    output: jsonb("output").$type<
+      InvestigationAgentOutput | IntegrationAgentOutput
+    >(),
+    errorMessage: text("error_message"),
+    startedAt: timestamp("started_at", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+  },
+  (table) => [
+    uniqueIndex("agent_executions_execution_agent_unique").on(
+      table.executionId,
+      table.agentId,
+    ),
+    check(
+      "agent_executions_role_check",
+      sql`${table.role} IN ('investigation', 'integration')`,
+    ),
+    check(
+      "agent_executions_status_check",
+      sql`${table.status} IN ('pending', 'running', 'completed', 'failed')`,
+    ),
+  ],
+);
+
+export type AgentExecutionRow = typeof agentExecutions.$inferSelect;
+export type NewAgentExecutionRow = typeof agentExecutions.$inferInsert;

--- a/packages/db/src/schema/agent-executions.ts
+++ b/packages/db/src/schema/agent-executions.ts
@@ -29,8 +29,13 @@ import {
 } from "drizzle-orm/pg-core";
 import { executions } from "./executions.ts";
 
+// `@agent-team-studio/shared` の `AgentRole` 型と値が重複している。
+// 一元化は別 Issue で扱う。
 export const AGENT_ROLES = ["investigation", "integration"] as const;
 
+// `@agent-team-studio/shared` の `AgentStatus` 型と
+// `executions.ts` の `EXECUTION_STATUSES` と値が重複している。
+// 一元化は別 Issue で扱う。
 export const AGENT_STATUSES = [
   "pending",
   "running",

--- a/packages/db/src/schema/agent-executions.ts
+++ b/packages/db/src/schema/agent-executions.ts
@@ -9,6 +9,8 @@
  *   DB レベルでの分岐検証は行わず、TS 側型で担保）
  * - UNIQUE (execution_id, agent_id): data-model.md §3 不変条件「同一 Execution 内で agent_id は一意」を DB で施行
  * - 親 Execution への FK は ON DELETE CASCADE（Execution 削除時に追従）
+ * - createdAt: 親 Execution と同タイミングで一括生成されるが、pending 状態の滞留時間を
+ *   追跡可能にするため独立した列として保持する（他テーブルとの一貫性も確保）
  */
 
 import type {
@@ -50,6 +52,9 @@ export const agentExecutions = pgTable(
       InvestigationAgentOutput | IntegrationAgentOutput
     >(),
     errorMessage: text("error_message"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
     startedAt: timestamp("started_at", { withTimezone: true }),
     completedAt: timestamp("completed_at", { withTimezone: true }),
   },
@@ -65,6 +70,15 @@ export const agentExecutions = pgTable(
     check(
       "agent_executions_status_check",
       sql`${table.status} IN ('pending', 'running', 'completed', 'failed')`,
+    ),
+    // 状態遷移の整合性を DB レベルで防衛する（executions と同じポリシー）。
+    check(
+      "agent_executions_completed_requires_started_check",
+      sql`${table.completedAt} IS NULL OR ${table.startedAt} IS NOT NULL`,
+    ),
+    check(
+      "agent_executions_completed_after_started_check",
+      sql`${table.startedAt} IS NULL OR ${table.completedAt} IS NULL OR ${table.completedAt} >= ${table.startedAt}`,
     ),
   ],
 );

--- a/packages/db/src/schema/executions.ts
+++ b/packages/db/src/schema/executions.ts
@@ -51,6 +51,17 @@ export const executions = pgTable(
       "executions_status_check",
       sql`${table.status} IN ('pending', 'running', 'completed', 'failed')`,
     ),
+    // 状態遷移の整合性を DB レベルで防衛する。
+    // started_at なしで completed_at が立つ／completed_at が started_at より過去、
+    // のいずれも論理的にあり得ないため CHECK で弾く（直接 SQL 操作・バグ対策）。
+    check(
+      "executions_completed_requires_started_check",
+      sql`${table.completedAt} IS NULL OR ${table.startedAt} IS NOT NULL`,
+    ),
+    check(
+      "executions_completed_after_started_check",
+      sql`${table.startedAt} IS NULL OR ${table.completedAt} IS NULL OR ${table.completedAt} >= ${table.startedAt}`,
+    ),
   ],
 );
 

--- a/packages/db/src/schema/executions.ts
+++ b/packages/db/src/schema/executions.ts
@@ -21,6 +21,9 @@ import {
 } from "drizzle-orm/pg-core";
 import { templates } from "./templates.ts";
 
+// `@agent-team-studio/shared` の `ExecutionStatus` 型 と
+// `agent-executions.ts` の `AGENT_STATUSES` と値が重複している。
+// 一元化（shared に as const 配列を置いて両者から import）は別 Issue で扱う。
 export const EXECUTION_STATUSES = [
   "pending",
   "running",

--- a/packages/db/src/schema/executions.ts
+++ b/packages/db/src/schema/executions.ts
@@ -1,0 +1,58 @@
+/**
+ * `executions` テーブル: テンプレートからの実行レコード。
+ *
+ * SSoT: docs/design/data-model.md §4.2, §5.2
+ *
+ * 物理スキーマの判断:
+ * - status: text + CHECK 制約（PG enum 型は値削除/変更が困難なため、変動期に強い text+CHECK を採用）
+ * - parameters: jsonb（テンプレート固有の入力。MVP は CompetitorAnalysisParameters のみ）
+ * - template への FK は ON DELETE RESTRICT（テンプレート消失で過去実行が宙吊りにならないよう保護）
+ */
+
+import type { CompetitorAnalysisParameters } from "@agent-team-studio/shared";
+import { sql } from "drizzle-orm";
+import {
+  check,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { templates } from "./templates.ts";
+
+export const EXECUTION_STATUSES = [
+  "pending",
+  "running",
+  "completed",
+  "failed",
+] as const;
+
+export const executions = pgTable(
+  "executions",
+  {
+    id: uuid("id").primaryKey().default(sql`uuidv7()`),
+    templateId: uuid("template_id")
+      .notNull()
+      .references(() => templates.id, { onDelete: "restrict" }),
+    parameters: jsonb("parameters")
+      .$type<CompetitorAnalysisParameters>()
+      .notNull(),
+    status: text("status", { enum: EXECUTION_STATUSES }).notNull(),
+    errorMessage: text("error_message"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    startedAt: timestamp("started_at", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+  },
+  (table) => [
+    check(
+      "executions_status_check",
+      sql`${table.status} IN ('pending', 'running', 'completed', 'failed')`,
+    ),
+  ],
+);
+
+export type ExecutionRow = typeof executions.$inferSelect;
+export type NewExecutionRow = typeof executions.$inferInsert;

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,0 +1,11 @@
+/**
+ * schema 集約 re-export。
+ *
+ * Drizzle migration / クエリで `import * as schema from "./schema"` できるよう、
+ * 全テーブル・enum 定数・行型を一括公開する。
+ */
+
+export * from "./agent-executions.ts";
+export * from "./executions.ts";
+export * from "./results.ts";
+export * from "./templates.ts";

--- a/packages/db/src/schema/results.ts
+++ b/packages/db/src/schema/results.ts
@@ -1,0 +1,43 @@
+/**
+ * `results` テーブル: Execution の最終成果物（Integration Agent 完了時のみ生成）。
+ *
+ * SSoT: docs/design/data-model.md §4.4, §3 不変条件
+ *
+ * 物理スキーマの判断:
+ * - structured: jsonb（CompetitorAnalysisResult。Integration Agent 出力と同型）
+ *   data-model.md §10 で「フィールド名は物理スキーマ確定時に再検討」とあったが、
+ *   論理モデルと同名 `structured` のまま採用（型名 CompetitorAnalysisResult との衝突は実害なし）
+ * - UNIQUE (execution_id): Execution : Result = 1 : 0..1（data-model.md §2）を DB で施行
+ * - 親 Execution への FK は ON DELETE CASCADE
+ */
+
+import type { CompetitorAnalysisResult } from "@agent-team-studio/shared";
+import { sql } from "drizzle-orm";
+import {
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { executions } from "./executions.ts";
+
+export const results = pgTable(
+  "results",
+  {
+    id: uuid("id").primaryKey().default(sql`uuidv7()`),
+    executionId: uuid("execution_id")
+      .notNull()
+      .references(() => executions.id, { onDelete: "cascade" }),
+    markdown: text("markdown").notNull(),
+    structured: jsonb("structured").$type<CompetitorAnalysisResult>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [uniqueIndex("results_execution_unique").on(table.executionId)],
+);
+
+export type ResultRow = typeof results.$inferSelect;
+export type NewResultRow = typeof results.$inferInsert;

--- a/packages/db/src/schema/templates.ts
+++ b/packages/db/src/schema/templates.ts
@@ -1,0 +1,33 @@
+/**
+ * `templates` テーブル: テンプレート定義の永続化。
+ *
+ * SSoT: docs/design/data-model.md §4.1
+ * - 論理モデル（属性・意味論）は data-model.md
+ * - 命名規約・ID 形式は packages/db/README.md
+ *
+ * 物理スキーマの判断:
+ * - id: UUIDv7（Postgres 18 ネイティブの uuidv7() で生成。時系列ソート可）
+ * - definition: jsonb（TemplateDefinition 型）。キー検索/部分更新は当面しない想定
+ * - timestamps: timestamptz（タイムゾーン付き）+ DB 既定値で生成
+ */
+
+import type { TemplateDefinition } from "@agent-team-studio/shared";
+import { sql } from "drizzle-orm";
+import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const templates = pgTable("templates", {
+  id: uuid("id").primaryKey().default(sql`uuidv7()`),
+  name: text("name").notNull(),
+  description: text("description").notNull(),
+  // jsonb<T>() で TS 側に型を伝搬する（DB 側は jsonb のまま）。
+  definition: jsonb("definition").$type<TemplateDefinition>().notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export type TemplateRow = typeof templates.$inferSelect;
+export type NewTemplateRow = typeof templates.$inferInsert;

--- a/packages/db/src/schema/templates.ts
+++ b/packages/db/src/schema/templates.ts
@@ -9,6 +9,12 @@
  * - id: UUIDv7（Postgres 18 ネイティブの uuidv7() で生成。時系列ソート可）
  * - definition: jsonb（TemplateDefinition 型）。キー検索/部分更新は当面しない想定
  * - timestamps: timestamptz（タイムゾーン付き）+ DB 既定値で生成
+ *
+ * updated_at の更新方針（MVP ではアプリ側で明示更新する）:
+ * MVP は templates をシード専用とし、ユーザーによるテンプレート編集は v2 以降の Non-goal
+ * （ADR-0005）。そのため UPDATE 時の自動更新トリガーは設けない。v2 でテンプレート編集を
+ * 実装する際に、以下のいずれかを選択する: (a) BEFORE UPDATE トリガーで自動更新、
+ * (b) アプリ側で UPDATE 時に updatedAt = now() を明示セット。実装時に再判断する。
  */
 
 import type { TemplateDefinition } from "@agent-team-studio/shared";

--- a/packages/db/src/seed-data/competitor-analysis.ts
+++ b/packages/db/src/seed-data/competitor-analysis.ts
@@ -164,6 +164,8 @@ export const competitorAnalysisDefinition: TemplateDefinition = {
     },
   ],
   llm: {
+    // model / temperature / max_tokens の SSoT は docs/design/llm-integration.md。
+    // ここはシードデータへの転記値。SSoT を更新したら本ファイルも合わせて更新する。
     model: "claude-sonnet-4-6",
     temperature_by_role: { investigation: 0.3, integration: 0.2 },
     max_tokens_by_role: { investigation: 2048, integration: 4096 },

--- a/packages/db/src/seed-data/competitor-analysis.ts
+++ b/packages/db/src/seed-data/competitor-analysis.ts
@@ -1,0 +1,174 @@
+/**
+ * 競合調査テンプレートのシードデータ定義。
+ *
+ * SSoT:
+ * - input_schema: docs/design/templates/competitor-analysis.md
+ * - system_prompt_template: docs/product/templates/competitor-analysis.md
+ * - LlmDefaults 値: docs/design/llm-integration.md
+ * - agents の構成: docs/product/templates/competitor-analysis.md
+ *
+ * 暫定: agent_id 命名規約は A4 (Issue #53) で確定するため、本ファイルは仮値を採用する。
+ * 確定後にこのファイルの agent_id を更新する。
+ */
+
+import type {
+  CompetitorPerspectiveKey,
+  TemplateDefinition,
+} from "@agent-team-studio/shared";
+
+// ---------- system prompt templates ----------
+// product doc の本文を転記。`{{...}}` プレースホルダの置換方式は A2 (Issue #52) で確定。
+// MVP では実行時にテンプレ展開ロジック側で対応する想定。
+
+const INVESTIGATION_AGENT_PROMPT = `あなたは企業リサーチの専門家です。指定された観点で、競合企業の直近動向を簡潔に整理します。
+
+## 観点
+{{perspective_name_ja}}（{{perspective_description}}）
+
+## 入力
+- 調査対象企業リスト: {{competitors}}
+- 参考情報（任意）: {{reference_or_empty}}
+
+## 指示
+1. 上記の各企業について、指定観点に関する要点を 3〜5 個の箇条書きで抽出する
+2. 根拠となる事実（製品名 / 数値 / 発表時期 / 関係者名など）を可能な範囲で含める
+3. 不明な点は「情報不足」と明記し、推測で埋めない
+4. 参考情報が提供されている場合は、その内容を優先的に参照する
+5. 最終出力は指定された JSON フォーマットに厳密に従う
+
+## 禁止事項
+- Web 検索や外部 URL へのアクセスを試みない（参考情報は事前提供のテキストのみ）
+- 事実と推測を混在させない
+- 他の観点（本エージェントの担当外）には言及しない
+
+## 出力フォーマット
+以下の構造の JSON のみを出力する。前後に説明文を付けない。
+
+- \`perspective\`: 本エージェントが担当する観点キー
+- \`findings\`: 競合企業ごとの調査結果配列（企業名・要点リスト・根拠レベル・補足）
+`;
+
+const INTEGRATION_AGENT_PROMPT = `あなたは事業戦略アナリストです。複数の観点で調査された情報を統合し、意思決定者が一覧比較しやすいマトリクス形式のレポートを生成します。
+
+## 入力
+- 調査対象企業リスト: {{competitors}}
+- Investigation Agent の出力（各観点の出力 JSON をまとめた配列）: {{investigation_results}}
+- 参考情報（任意）: {{reference_or_empty}}
+
+## 指示
+1. 観点×競合のマトリクスを生成する。行＝観点（戦略 / 製品 / 投資 / パートナーシップ）、列＝競合企業
+2. 各セルには、その観点×企業で最も重要な 1〜3 点を簡潔に記述する
+3. 観点をまたいだ全体所見（3〜5 行）をマトリクスの末尾に追加する
+4. ある観点の Investigation Agent 出力が欠落している、もしくは該当競合の全 findings が \`evidence_level: insufficient\` の場合、その観点を \`missing\` 配列に入れ、\`matrix[].cells\` には含めない
+5. 出力は Markdown と、内部保持用 JSON の 2 形式。両者が同一内容を指すこと
+
+## 禁止事項
+- 入力にない情報を捏造しない
+- 企業ごと・観点ごとの分量を極端に偏らせない
+- Investigation Agent の出力と矛盾する記述をしない（矛盾を発見した場合は「Investigation Agent 間で情報に齟齬あり」と所見欄に明記する）
+
+## 出力フォーマット
+以下の 2 ブロックを続けて出力する。
+
+### 1. Markdown レポート
+- 見出し構造は「## 観点×競合マトリクス」→ 表 → 「## 全体所見」の順
+- 表のヘッダ: 空セル + 競合企業名
+- 行ヘッダ: 観点の日本語ラベル。\`missing\` に含まれる観点の行は、全セルを「情報不足」と記述する
+
+### 2. 内部 JSON
+以下の構造で出力する。
+
+- \`matrix\`: 観点ごとのセル配列（観点キー・競合企業名・要約・根拠レベル）
+- \`overall_insights\`: 観点横断の全体所見
+- \`missing\`: 欠落した観点とその理由
+`;
+
+// ---------- 観点メタデータ ----------
+// product doc の §観点の意味づけ から転記。表示順 strategy → product → investment → partnership。
+
+type Perspective = {
+  key: CompetitorPerspectiveKey;
+  name_ja: string;
+  description: string;
+};
+
+const PERSPECTIVES: Perspective[] = [
+  {
+    key: "strategy",
+    name_ja: "戦略",
+    description:
+      "事業ミッション・ビジョン、注力セグメント、地理的展開、直近の戦略発表、組織再編",
+  },
+  {
+    key: "product",
+    name_ja: "製品",
+    description:
+      "主力プロダクトの機能・価格、直近のリリース / アップデート、差別化ポイント、ターゲット顧客層",
+  },
+  {
+    key: "investment",
+    name_ja: "投資",
+    description:
+      "直近の資金調達（金額・投資家・バリュエーション）、M&A の実施 / 対象、主要株主の動向",
+  },
+  {
+    key: "partnership",
+    name_ja: "パートナーシップ",
+    description:
+      "技術提携・販売提携・共同開発、主要顧客 / 導入事例、エコシステム（プラグイン・SDK 等）の連携先",
+  },
+];
+
+// ---------- TemplateDefinition ----------
+
+export const COMPETITOR_ANALYSIS_TEMPLATE_NAME = "競合調査";
+
+export const competitorAnalysisDefinition: TemplateDefinition = {
+  schema_version: "1",
+  input_schema: {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    title: "CompetitorAnalysisParameters",
+    type: "object",
+    required: ["competitors"],
+    properties: {
+      competitors: {
+        type: "array",
+        description: "調査対象の競合企業名",
+        items: { type: "string", minLength: 1, maxLength: 100 },
+        minItems: 1,
+        maxItems: 5,
+      },
+      reference: {
+        type: "string",
+        description:
+          "ユーザーが任意で貼り付ける参考情報。URL を貼り付けても Web 取得は行わない",
+        maxLength: 10000,
+      },
+    },
+  },
+  agents: [
+    ...PERSPECTIVES.map((p) => ({
+      role: "investigation" as const,
+      agent_id: `investigation_${p.key}`,
+      specialization: {
+        perspective_key: p.key,
+        perspective_name_ja: p.name_ja,
+        perspective_description: p.description,
+      },
+      system_prompt_template: INVESTIGATION_AGENT_PROMPT,
+    })),
+    {
+      role: "integration",
+      agent_id: "integration",
+      system_prompt_template: INTEGRATION_AGENT_PROMPT,
+    },
+  ],
+  llm: {
+    model: "claude-sonnet-4-6",
+    temperature_by_role: { investigation: 0.3, integration: 0.2 },
+    max_tokens_by_role: { investigation: 2048, integration: 4096 },
+  },
+};
+
+export const competitorAnalysisDescription =
+  "競合企業を 4 観点（戦略 / 製品 / 投資 / パートナーシップ）で並列調査し、意思決定向けマトリクスに統合する MVP シードテンプレート。";

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -9,7 +9,9 @@
  * 冪等性: name を一意キーとして既存チェック。再実行しても重複しない。
  *  - DB レベルの UNIQUE 制約は付けない（MVP は seed 1 件のみで運用上必要なし）
  *  - SELECT → INSERT 間に TOCTOU の隙はあるが、seed は単一プロセス前提のため実害なし。
- *    将来 CI 並列化等で並行実行が発生する前に `ON CONFLICT DO NOTHING` 方式へ切替えること
+ *    将来 CI 並列化等で並行実行が発生する前に `ON CONFLICT DO NOTHING` 方式へ切替えること。
+ *    切替えは構文上 `templates.name` に UNIQUE 制約が必須となるため、
+ *    schema 変更 + migration 追加とセットで行う
  */
 
 import { eq } from "drizzle-orm";

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -3,9 +3,13 @@
  *
  * `bun run db:seed` の実体。MVP では競合調査テンプレート 1 件のみを投入する。
  *
+ * 本ファイルは関数 `seedTemplates` を export する形にして、将来テストや別スクリプトで
+ * 再利用できるようにする。CLI から直接呼ばれた場合のみ Pool を作って実行する。
+ *
  * 冪等性: name を一意キーとして既存チェック。再実行しても重複しない。
  *  - DB レベルの UNIQUE 制約は付けない（MVP は seed 1 件のみで運用上必要なし）
- *  - 将来テンプレートが増えたら id を固定にして ON CONFLICT DO NOTHING に切替検討
+ *  - SELECT → INSERT 間に TOCTOU の隙はあるが、seed は単一プロセス前提のため実害なし。
+ *    将来 CI 並列化等で並行実行が発生する前に `ON CONFLICT DO NOTHING` 方式へ切替えること
  */
 
 import { eq } from "drizzle-orm";
@@ -18,16 +22,9 @@ import {
   competitorAnalysisDescription,
 } from "./seed-data/competitor-analysis.ts";
 
-const databaseUrl = process.env.DATABASE_URL;
-if (!databaseUrl) {
-  throw new Error("DATABASE_URL is not set");
-}
+type DrizzleDb = ReturnType<typeof drizzle>;
 
-const pool = new Pool({ connectionString: databaseUrl });
-
-try {
-  const db = drizzle(pool);
-
+export async function seedTemplates(db: DrizzleDb): Promise<void> {
   const existing = await db
     .select({ id: templates.id })
     .from(templates)
@@ -37,16 +34,29 @@ try {
     console.log(
       `seed: template "${COMPETITOR_ANALYSIS_TEMPLATE_NAME}" already exists, skipping`,
     );
-  } else {
-    await db.insert(templates).values({
-      name: COMPETITOR_ANALYSIS_TEMPLATE_NAME,
-      description: competitorAnalysisDescription,
-      definition: competitorAnalysisDefinition,
-    });
-    console.log(
-      `seed: inserted template "${COMPETITOR_ANALYSIS_TEMPLATE_NAME}"`,
-    );
+    return;
   }
-} finally {
-  await pool.end();
+
+  await db.insert(templates).values({
+    name: COMPETITOR_ANALYSIS_TEMPLATE_NAME,
+    description: competitorAnalysisDescription,
+    definition: competitorAnalysisDefinition,
+  });
+  console.log(`seed: inserted template "${COMPETITOR_ANALYSIS_TEMPLATE_NAME}"`);
+}
+
+// CLI として直接実行された場合のみ Pool を起こす。
+// テストや別スクリプトから `seedTemplates(db)` として呼ばれた場合は実行されない。
+if (import.meta.main) {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not set");
+  }
+
+  const pool = new Pool({ connectionString: databaseUrl });
+  try {
+    await seedTemplates(drizzle(pool));
+  } finally {
+    await pool.end();
+  }
 }

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,0 +1,52 @@
+/**
+ * 初期データ投入スクリプト。
+ *
+ * `bun run db:seed` の実体。MVP では競合調査テンプレート 1 件のみを投入する。
+ *
+ * 冪等性: name を一意キーとして既存チェック。再実行しても重複しない。
+ *  - DB レベルの UNIQUE 制約は付けない（MVP は seed 1 件のみで運用上必要なし）
+ *  - 将来テンプレートが増えたら id を固定にして ON CONFLICT DO NOTHING に切替検討
+ */
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { templates } from "./schema/index.ts";
+import {
+  COMPETITOR_ANALYSIS_TEMPLATE_NAME,
+  competitorAnalysisDefinition,
+  competitorAnalysisDescription,
+} from "./seed-data/competitor-analysis.ts";
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+const pool = new Pool({ connectionString: databaseUrl });
+
+try {
+  const db = drizzle(pool);
+
+  const existing = await db
+    .select({ id: templates.id })
+    .from(templates)
+    .where(eq(templates.name, COMPETITOR_ANALYSIS_TEMPLATE_NAME));
+
+  if (existing.length > 0) {
+    console.log(
+      `seed: template "${COMPETITOR_ANALYSIS_TEMPLATE_NAME}" already exists, skipping`,
+    );
+  } else {
+    await db.insert(templates).values({
+      name: COMPETITOR_ANALYSIS_TEMPLATE_NAME,
+      description: competitorAnalysisDescription,
+      definition: competitorAnalysisDefinition,
+    });
+    console.log(
+      `seed: inserted template "${COMPETITOR_ANALYSIS_TEMPLATE_NAME}"`,
+    );
+  }
+} finally {
+  await pool.end();
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -13,16 +13,13 @@
  */
 
 import { eq } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/node-postgres";
-import { Pool } from "pg";
+import { createDbClient, type DrizzleDb } from "./client.ts";
 import { templates } from "./schema/index.ts";
 import {
   COMPETITOR_ANALYSIS_TEMPLATE_NAME,
   competitorAnalysisDefinition,
   competitorAnalysisDescription,
 } from "./seed-data/competitor-analysis.ts";
-
-type DrizzleDb = ReturnType<typeof drizzle>;
 
 export async function seedTemplates(db: DrizzleDb): Promise<void> {
   const existing = await db
@@ -45,7 +42,7 @@ export async function seedTemplates(db: DrizzleDb): Promise<void> {
   console.log(`seed: inserted template "${COMPETITOR_ANALYSIS_TEMPLATE_NAME}"`);
 }
 
-// CLI として直接実行された場合のみ Pool を起こす。
+// CLI として直接実行された場合のみ DB クライアントを起こす。
 // テストや別スクリプトから `seedTemplates(db)` として呼ばれた場合は実行されない。
 if (import.meta.main) {
   const databaseUrl = process.env.DATABASE_URL;
@@ -53,10 +50,10 @@ if (import.meta.main) {
     throw new Error("DATABASE_URL is not set");
   }
 
-  const pool = new Pool({ connectionString: databaseUrl });
+  const client = createDbClient(databaseUrl);
   try {
-    await seedTemplates(drizzle(pool));
+    await seedTemplates(client.db);
   } finally {
-    await pool.end();
+    await client.close();
   }
 }

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"]
+  "include": ["src", "drizzle.config.ts"],
+  "compilerOptions": {
+    "types": ["bun", "node"]
+  }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,18 @@
       "outputs": [
         "dist/**"
       ]
+    },
+    "db:generate": {
+      "cache": false,
+      "env": ["DATABASE_URL"]
+    },
+    "db:migrate": {
+      "cache": false,
+      "env": ["DATABASE_URL"]
+    },
+    "db:seed": {
+      "cache": false,
+      "env": ["DATABASE_URL"]
     }
   }
 }


### PR DESCRIPTION
## What

`packages/db` に MVP データモデルの物理スキーマ・migration 基盤・シードデータを実装した。

- 4 テーブル（`templates` / `executions` / `agent_executions` / `results`）の Drizzle schema
- drizzle-kit による migration 生成・適用基盤（`db:generate` / `db:migrate`）
- 競合調査テンプレートの冪等な seed スクリプト（`db:seed`）
- `packages/db/README.md` を物理スキーマ規約の SSoT として整備
- docker-compose のデフォルトネットワーク名を明示（ガードレール）

## Why

- closes #78
- MVP 実装着手前の準備（親 Issue #75）の必須前提。`docs/design/data-model.md §10` の物理スキーマ未確定事項を本 PR で確定し、Walking Skeleton（#82）と US-1〜US-5 の DB 前提を整える

## How

### 物理スキーマ判断

| 観点 | 採用 | 理由 |
| --- | --- | --- |
| ID 形式 | UUIDv7（PG 18 ネイティブ `uuidv7()`）| RFC 標準 + 時系列ソート + PG ネイティブ型 |
| enum 表現 | `text` + CHECK 制約 | MVP 変動期に強い（PG enum 型は値削除困難） |
| timestamp | `timestamp with time zone` | TZ 意識不要、`defaultNow()` で DB 側生成 |
| FK ポリシー | templates→RESTRICT / executions→CASCADE | 履歴保持と追従の使い分け |
| UNIQUE 制約 | `(execution_id, agent_id)` / `(execution_id)` on results | data-model.md §3 不変条件を DB で施行 |
| テスト DB 戦略 | truncate-per-test（README に明記） | MVP のテスト本数規模で最低設定 |

詳細は `packages/db/README.md` を SSoT として記述。

### コミット構成

- `feat(db): MVP データモデルの Drizzle schema 初版 #78`
- `feat(db): drizzle-kit 設定と migration 生成基盤 #78`
- `feat(db): 競合調査テンプレートの seed と README SSoT #78`
- `chore(project): docker-compose のデフォルトネットワーク名を明示 #78`

### ネットワーク明示の経緯

検証中に app コンテナと db コンテナが別ネットワークに分離する事故が発生（DevContainer 起動経路と compose project 名再生成の影響、ADR-0018 で言及あり）。Rebuild Container で復旧確認した上で、再発防止のガードレールとして `networks.default.name` を `agent-team-studio` に固定。

## Checklist

- [x] `bun run lint` 緑
- [x] `bun run type-check` 緑
- [x] `bun run lint:md` 緑
- [x] `bun run lint:secret` 緑
- [x] `bun run db:generate` で migration 生成確認
- [x] `bun run db:migrate` でスキーマ適用確認（実機検証済）
- [x] `bun run db:seed` で競合調査テンプレート 1 件投入確認（冪等性も確認）
- [x] `packages/db/README.md` に SSoT 記述

## 後続 Issue で確定する事項

- `agent_id` 命名規約の最終形 → A4（#53）
- LLM クライアント差し替え方針 → 最初の agent-core Issue
- ネットワーク分離問題が transient だったか恒久対策が必要か → 別途 chore Issue で再発時に判断（現状は明示でカバー）

## 関連

- 親 Issue #75
- ADR-0014 MVP データモデル設計方針
- ADR-0018 compose ルート配置（network 明示の文脈）
- `docs/design/data-model.md`