### PR TITLE
refactor(shared): status / role enum 値を shared に一元化 #97

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "lint": "biome check src/",
     "type-check": "tsc --noEmit",
+    "test": "bun test",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "bun run src/migrate.ts",
     "db:seed": "bun run src/seed.ts"

--- a/packages/db/src/schema/_helpers.test.ts
+++ b/packages/db/src/schema/_helpers.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import {
+  AGENT_ROLES,
+  AGENT_STATUSES,
+  EXECUTION_STATUSES,
+} from "@agent-team-studio/shared";
 import { PgDialect } from "drizzle-orm/pg-core";
 import { sqlLiteralList } from "./_helpers.ts";
 
@@ -25,5 +30,20 @@ describe("sqlLiteralList", () => {
   test("値はパラメータ化されず raw リテラルとして埋め込まれる（CHECK 制約 DDL での使用が前提）", () => {
     const result = sqlLiteralList(["a", "b"]);
     expect(dialect.sqlToQuery(result).params).toEqual([]);
+  });
+
+  // shared 側の値が CHECK 制約 SQL に直接反映されることを保証する結合テスト。
+  // shared の値変更（例: ADR-0014 の partial_failure 追加）が migration へ
+  // 期待どおり伝播するかをここで検知する。
+  test("shared の SSoT 配列を渡すと現行 CHECK 制約と一致する SQL を生成する", () => {
+    expect(dialect.sqlToQuery(sqlLiteralList(EXECUTION_STATUSES)).sql).toBe(
+      "'pending', 'running', 'completed', 'failed'",
+    );
+    expect(dialect.sqlToQuery(sqlLiteralList(AGENT_STATUSES)).sql).toBe(
+      "'pending', 'running', 'completed', 'failed'",
+    );
+    expect(dialect.sqlToQuery(sqlLiteralList(AGENT_ROLES)).sql).toBe(
+      "'investigation', 'integration'",
+    );
   });
 });

--- a/packages/db/src/schema/_helpers.test.ts
+++ b/packages/db/src/schema/_helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { sqlLiteralList } from "./_helpers.ts";
+
+const dialect = new PgDialect();
+
+describe("sqlLiteralList", () => {
+  test("as const 配列をシングルクォート区切りの SQL リテラル列に展開する", () => {
+    const result = sqlLiteralList([
+      "pending",
+      "running",
+      "completed",
+      "failed",
+    ]);
+    expect(dialect.sqlToQuery(result).sql).toBe(
+      "'pending', 'running', 'completed', 'failed'",
+    );
+  });
+
+  test("単一要素でも正しく展開される", () => {
+    const result = sqlLiteralList(["investigation"]);
+    expect(dialect.sqlToQuery(result).sql).toBe("'investigation'");
+  });
+
+  test("値はパラメータ化されず raw リテラルとして埋め込まれる（CHECK 制約 DDL での使用が前提）", () => {
+    const result = sqlLiteralList(["a", "b"]);
+    expect(dialect.sqlToQuery(result).params).toEqual([]);
+  });
+});

--- a/packages/db/src/schema/_helpers.ts
+++ b/packages/db/src/schema/_helpers.ts
@@ -6,12 +6,17 @@
 import { type SQL, sql } from "drizzle-orm";
 
 /**
- * CHECK 制約用に `('a', 'b', 'c')` の SQL 断片を生成する。
+ * CHECK 制約用に `'a', 'b', 'c'` の SQL 断片を生成する（呼び出し側の `IN (...)` 内に埋め込む想定）。
  *
- * 値は `as const` 配列の静的定数（shared の `EXECUTION_STATUSES` 等）を想定するため、
- * `sql.raw` でリテラル展開して問題ない（SQL インジェクション経路なし）。
- * これにより CHECK の SQL リテラルと TS 側の値配列が同じ SSoT から導出される。
+ * `sql.raw` でリテラル展開するため、引数は **コンパイル時に値が確定する `as const` 配列**
+ * （shared の `EXECUTION_STATUSES` 等）に限定する。動的文字列・ユーザー入力を渡すと
+ * SQL インジェクション経路になる。
+ *
+ * 型 `readonly [string, ...string[]]`（非空タプル）により以下を強制する:
+ * - `as const` 配列はタプル型として推論されるため代入可
+ * - `arr.map()` 等の動的配列は `string[]` 型のため代入不可（`as` キャストでのみ通る）
+ * - 空配列は最低 1 要素制約により代入不可（`IN ()` の不正 SQL を防止）
  */
-export function sqlLiteralList(values: readonly string[]): SQL {
+export function sqlLiteralList(values: readonly [string, ...string[]]): SQL {
   return sql.raw(values.map((v) => `'${v}'`).join(", "));
 }

--- a/packages/db/src/schema/_helpers.ts
+++ b/packages/db/src/schema/_helpers.ts
@@ -1,0 +1,17 @@
+/**
+ * schema 内部ヘルパ。`schema/index.ts` の barrel re-export には含めない
+ * （`_` プレフィックスはパッケージ内部限定の意図を示す）。
+ */
+
+import { type SQL, sql } from "drizzle-orm";
+
+/**
+ * CHECK 制約用に `('a', 'b', 'c')` の SQL 断片を生成する。
+ *
+ * 値は `as const` 配列の静的定数（shared の `EXECUTION_STATUSES` 等）を想定するため、
+ * `sql.raw` でリテラル展開して問題ない（SQL インジェクション経路なし）。
+ * これにより CHECK の SQL リテラルと TS 側の値配列が同じ SSoT から導出される。
+ */
+export function sqlLiteralList(values: readonly string[]): SQL {
+  return sql.raw(values.map((v) => `'${v}'`).join(", "));
+}

--- a/packages/db/src/schema/agent-executions.ts
+++ b/packages/db/src/schema/agent-executions.ts
@@ -13,9 +13,11 @@
  *   追跡可能にするため独立した列として保持する（他テーブルとの一貫性も確保）
  */
 
-import type {
-  IntegrationAgentOutput,
-  InvestigationAgentOutput,
+import {
+  AGENT_ROLES,
+  AGENT_STATUSES,
+  type IntegrationAgentOutput,
+  type InvestigationAgentOutput,
 } from "@agent-team-studio/shared";
 import { sql } from "drizzle-orm";
 import {
@@ -27,21 +29,8 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
+import { sqlLiteralList } from "./_helpers.ts";
 import { executions } from "./executions.ts";
-
-// `@agent-team-studio/shared` の `AgentRole` 型と値が重複している。
-// 一元化は別 Issue で扱う。
-export const AGENT_ROLES = ["investigation", "integration"] as const;
-
-// `@agent-team-studio/shared` の `AgentStatus` 型と
-// `executions.ts` の `EXECUTION_STATUSES` と値が重複している。
-// 一元化は別 Issue で扱う。
-export const AGENT_STATUSES = [
-  "pending",
-  "running",
-  "completed",
-  "failed",
-] as const;
 
 export const agentExecutions = pgTable(
   "agent_executions",
@@ -70,11 +59,11 @@ export const agentExecutions = pgTable(
     ),
     check(
       "agent_executions_role_check",
-      sql`${table.role} IN ('investigation', 'integration')`,
+      sql`${table.role} IN (${sqlLiteralList(AGENT_ROLES)})`,
     ),
     check(
       "agent_executions_status_check",
-      sql`${table.status} IN ('pending', 'running', 'completed', 'failed')`,
+      sql`${table.status} IN (${sqlLiteralList(AGENT_STATUSES)})`,
     ),
     // 状態遷移の整合性を DB レベルで防衛する（executions と同じポリシー）。
     check(

--- a/packages/db/src/schema/executions.ts
+++ b/packages/db/src/schema/executions.ts
@@ -9,7 +9,10 @@
  * - template への FK は ON DELETE RESTRICT（テンプレート消失で過去実行が宙吊りにならないよう保護）
  */
 
-import type { CompetitorAnalysisParameters } from "@agent-team-studio/shared";
+import {
+  type CompetitorAnalysisParameters,
+  EXECUTION_STATUSES,
+} from "@agent-team-studio/shared";
 import { sql } from "drizzle-orm";
 import {
   check,
@@ -19,17 +22,8 @@ import {
   timestamp,
   uuid,
 } from "drizzle-orm/pg-core";
+import { sqlLiteralList } from "./_helpers.ts";
 import { templates } from "./templates.ts";
-
-// `@agent-team-studio/shared` の `ExecutionStatus` 型 と
-// `agent-executions.ts` の `AGENT_STATUSES` と値が重複している。
-// 一元化（shared に as const 配列を置いて両者から import）は別 Issue で扱う。
-export const EXECUTION_STATUSES = [
-  "pending",
-  "running",
-  "completed",
-  "failed",
-] as const;
 
 export const executions = pgTable(
   "executions",
@@ -52,7 +46,7 @@ export const executions = pgTable(
   (table) => [
     check(
       "executions_status_check",
-      sql`${table.status} IN ('pending', 'running', 'completed', 'failed')`,
+      sql`${table.status} IN (${sqlLiteralList(EXECUTION_STATUSES)})`,
     ),
     // 状態遷移の整合性を DB レベルで防衛する。
     // started_at なしで completed_at が立つ／completed_at が started_at より過去、

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -3,6 +3,8 @@
  *
  * Drizzle migration / クエリで `import * as schema from "./schema"` できるよう、
  * 全テーブル・enum 定数・行型を一括公開する。
+ *
+ * `_helpers.ts` は `_` プレフィックスのとおりパッケージ内部限定のため barrel から除外する。
  */
 
 export * from "./agent-executions.ts";

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -16,12 +16,36 @@ export type ResultId = string;
 
 // ---------- 共通 enum ----------
 
-/** AgentExecution / Execution の状態（data-model.md §5）。 */
-export type ExecutionStatus = "pending" | "running" | "completed" | "failed";
-export type AgentStatus = "pending" | "running" | "completed" | "failed";
+// SSoT として `as const` 配列を置き、TS union 型と DB schema 用の
+// 値配列の双方をここから派生させる（packages/db の `text("col", { enum })` /
+// CHECK 制約 SQL も import して再利用する）。
+//
+// `EXECUTION_STATUSES` と `AGENT_STATUSES` は MVP 時点では値が完全一致するが、
+// ADR-0014 §中立で Execution 側のみ `partial_failure` 追加が示唆されているため
+// 分離維持する（Issue #97 の方針）。
 
-/** エージェントの役割（data-model.md §4.3）。 */
-export type AgentRole = "investigation" | "integration";
+/** Execution.status の取りうる値（data-model.md §5）。 */
+export const EXECUTION_STATUSES = [
+  "pending",
+  "running",
+  "completed",
+  "failed",
+] as const;
+
+/** AgentExecution.status の取りうる値（data-model.md §5）。 */
+export const AGENT_STATUSES = [
+  "pending",
+  "running",
+  "completed",
+  "failed",
+] as const;
+
+/** AgentExecution.role の取りうる値（data-model.md §4.3）。 */
+export const AGENT_ROLES = ["investigation", "integration"] as const;
+
+export type ExecutionStatus = (typeof EXECUTION_STATUSES)[number];
+export type AgentStatus = (typeof AGENT_STATUSES)[number];
+export type AgentRole = (typeof AGENT_ROLES)[number];
 
 /** 個別エージェントの失敗理由（agent-execution.md §5）。 */
 export type AgentFailReason =

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -5,10 +5,8 @@
  * 命名規約は data-model.md §6 の TS 例に合わせて snake_case を採用する。
  * REST/WS 境界での camelCase は api-types.ts / ws-types.ts 側で定義する。
  *
- * 本ファイルは TS 型と DB CHECK 制約値の両方の SSoT を兼ねる。
- * 値の取りうる集合（status / role / fail reason 等）は `as const` 配列で定義し、
- * union 型は `(typeof X)[number]` で派生させる。`packages/db` の schema は
- * 同配列を import して `text("col", { enum })` と CHECK 制約 SQL の双方を構築する。
+ * 本ファイルは TS 型と DB CHECK 制約値の双方の SSoT を兼ねる
+ * （`as const` 配列の運用方針は「共通 enum」セクションを参照）。
  */
 
 // ---------- 識別子 ----------
@@ -21,9 +19,9 @@ export type ResultId = string;
 
 // ---------- 共通 enum ----------
 
-// SSoT として `as const` 配列を置き、TS union 型と DB schema 用の
-// 値配列の双方をここから派生させる（packages/db の `text("col", { enum })` /
-// CHECK 制約 SQL も import して再利用する）。
+// SSoT として `as const` 配列を置き、TS union 型と DB schema 用の値配列の双方を
+// ここから派生させる。`packages/db` の schema は同配列を import して
+// `text("col", { enum })` と CHECK 制約 SQL の双方を構築する。
 //
 // `EXECUTION_STATUSES` と `AGENT_STATUSES` は MVP 時点では値が完全一致するが、
 // ADR-0014 §中立で Execution 側のみ `partial_failure` 追加が示唆されているため

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -4,6 +4,11 @@
  * SSoT: docs/design/data-model.md / docs/design/templates/competitor-analysis.md
  * 命名規約は data-model.md §6 の TS 例に合わせて snake_case を採用する。
  * REST/WS 境界での camelCase は api-types.ts / ws-types.ts 側で定義する。
+ *
+ * 本ファイルは TS 型と DB CHECK 制約値の両方の SSoT を兼ねる。
+ * 値の取りうる集合（status / role / fail reason 等）は `as const` 配列で定義し、
+ * union 型は `(typeof X)[number]` で派生させる。`packages/db` の schema は
+ * 同配列を import して `text("col", { enum })` と CHECK 制約 SQL の双方を構築する。
  */
 
 // ---------- 識別子 ----------
@@ -48,17 +53,22 @@ export type AgentStatus = (typeof AGENT_STATUSES)[number];
 export type AgentRole = (typeof AGENT_ROLES)[number];
 
 /** 個別エージェントの失敗理由（agent-execution.md §5）。 */
-export type AgentFailReason =
-  | "llm_error"
-  | "output_parse_error"
-  | "timeout"
-  | "internal_error";
+export const AGENT_FAIL_REASONS = [
+  "llm_error",
+  "output_parse_error",
+  "timeout",
+  "internal_error",
+] as const;
 
 /** Execution 全体の失敗理由（agent-execution.md §5）。 */
-export type ExecutionFailReason =
-  | "all_investigations_failed"
-  | "integration_failed"
-  | "timeout";
+export const EXECUTION_FAIL_REASONS = [
+  "all_investigations_failed",
+  "integration_failed",
+  "timeout",
+] as const;
+
+export type AgentFailReason = (typeof AGENT_FAIL_REASONS)[number];
+export type ExecutionFailReason = (typeof EXECUTION_FAIL_REASONS)[number];
 
 // ---------- Template ----------
 


### PR DESCRIPTION
## What

ステータス値・ロール値の SSoT を `packages/shared` に一本化した。これまで 3 箇所（`shared` の TS union 型、`packages/db` の 2 つの schema ファイルに `as const` 配列、加えて CHECK 制約 SQL のリテラル）に分散していた値を、shared の `as const` 配列を唯一の SSoT として両者から派生させる構造に変更。

- `packages/shared/src/domain-types.ts` に `EXECUTION_STATUSES` / `AGENT_STATUSES` / `AGENT_ROLES` を `as const` 配列として追加し、対応する union 型を `(typeof X)[number]` で派生
- `packages/db/src/schema/executions.ts` / `agent-executions.ts` のローカル定数を削除し、shared から import
- `packages/db/src/schema/_helpers.ts` を新設。`sqlLiteralList()` で CHECK 制約 SQL の `('a', 'b', ...)` 部分を配列から動的生成
- 各 schema ファイルの「別 Issue で扱う」暫定コメントを除去

## Why

closes #97

- 値レベルの重複は TS が検出できない（型重複は検出するが配列値の不整合はサイレント）
- ADR-0014 §中立で `Execution.status` への `partial_failure` 追加可能性が言及されており、近い将来に値が変動する可能性がある
- PR #95 のレビュー（3 回目 should #2）で指摘されたが migration 再生成のスコープ拡大を避けるため別 Issue に切り出されていた回収タスク

## How

### 判断ポイント

- **`EXECUTION_STATUSES` と `AGENT_STATUSES` は分離維持**: MVP 時点では値が完全一致だが、ADR-0014 で Execution 側のみ `partial_failure` 追加が示唆されているため統合せず分離（Issue 方針どおり）
- **CHECK 制約 SQL の動的化を実施**: `sql.raw` で配列をリテラル展開する方針で成功。値は `as const` 配列の静的定数のため SQL インジェクション経路はなし。生成される SQL は元と完全一致

### migration 差分の有無

`bun run db:generate` 結果: `No schema changes, nothing to migrate`（差分なし）。CHECK 制約の SQL 文字列が以前と完全一致したため migration 再生成は不要。Issue 受け入れ条件「migration 差分の発生有無を Issue コメントに記録」に対しては差分なしを記録する。

## Checklist

- [x] `bun run lint` 緑
- [x] `bun run type-check` 緑
- [x] `bun run lint:md` 緑
- [x] `bun run lint:secret` 緑
- [x] `bun run test` 緑（11 pass）
- [x] `bun run db:generate` 緑（差分なし）
- [ ] `bun run db:migrate` 緑（サンドボックスに Docker がないため未実行 / 差分ゼロのため no-op となる想定。実機検証は DevContainer で別途実施）

## 関連

- Issue #97
- PR #95（指摘元）
- ADR-0014 MVP データモデル設計方針

---
_Generated by [Claude Code](https://claude.ai/code/session_019GnJsPB8icr5JjCAdEhzFZ)_