### PR TITLE
chore(devcontainer): gh CLI 認証情報を named volume で永続化

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,4 +4,7 @@ set -euo pipefail
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends postgresql-client
 
+# named volume で永続化する gh CLI 認証情報の保存先を node 所有で用意する。
+sudo install -d -o node -g node -m 700 /home/node/.config /home/node/.config/gh
+
 bun install

--- a/cspell.json
+++ b/cspell.json
@@ -9,6 +9,8 @@
   "dictionaries": [],
   "words": [
     "bunx",
+    "healthcheck",
+    "isready",
     "ISTQB",
     "JTBD",
     "kuairen",
@@ -18,6 +20,7 @@
     "mstyle",
     "Nygard",
     "oneline",
+    "pgdata",
     "psql",
     "Turborepo",
     "Worktree",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - .:/workspaces/agent-team-studio:cached
       - claude-home:/home/node/.claude
+      - gh-config:/home/node/.config/gh
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:?env_required}:${POSTGRES_PASSWORD:?env_required}@db:5432/${POSTGRES_DB:?env_required}
       WORKTREE_ID: ${WORKTREE_ID:?env_required}
@@ -42,6 +43,8 @@ services:
 volumes:
   claude-home:
     name: agent-team-studio-claude-home
+  gh-config:
+    name: agent-team-studio-gh-config
   pgdata:
     # サービス定義内の論理参照名は pgdata 固定だが、外部 volume 名（Docker が管理する実名）は
     # DB_VOLUME で動的に切替する（worktree 単位の DB 隔離用）


### PR DESCRIPTION
## What

- `docker-compose.yml` に `gh-config` named volume を追加し、`/home/node/.config/gh` を永続化
- `.devcontainer/post-create.sh` で `node` 所有の `~/.config/gh` ディレクトリを 700 で作成（マウント先の所有権を整える）
- `cspell.json` に compose 関連語（`healthcheck`, `isready`, `pgdata`）を追加

## Why

DevContainer 再生成のたびに `gh auth login` を再実行する手間を解消する。`claude-home` と同じ named volume 方式で `gh` CLI の認証情報を保持する。

## How

- ボリューム名は `agent-team-studio-gh-config` で他の volume 命名規約に揃える
- `~/.config/gh` の権限は `gh` の推奨に合わせて 700
- post-create.sh は idempotent（`install -d` で既存時は no-op）

## Checklist

- [x] DevContainer 再生成後も `gh auth status` が認証済みのままになることを確認
- [x] 既存の `claude-home` 等の永続化方式と整合