### PR TITLE
chore(project): WebSocket + LLM streaming + AbortSignal 貫通検証 (Spike) #81

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -15,6 +15,7 @@
 | [agent-execution.md](./agent-execution.md) | エージェント実行アーキテクチャ（並列実行モデル・進捗イベント契約・状態確定フロー・タイムアウト） |
 | [ui-patterns.md](./ui-patterns.md) | UI/UX デザイン原則・状態パターン・グローバルナビ・shadcn/ui マッピング・Tailwind トークン・アクセシビリティ・URL ルーティング |
 | [templates/](./templates/README.md) | テンプレート固有の I/O スキーマ（入力 JSON Schema・内部 JSON 出力型）。プロダクト視点の仕様は [docs/product/templates/](../product/templates/README.md)、横断事項は A2/A3/A4 側で確定 |
+| [technotes/](./technotes/) | 検証ノート（Spike 結果・実機挙動の記録）。設計 doc の根拠として参照される |
 
 ## 配置ガイドライン
 

--- a/docs/design/technotes/ws-llm-spike.md
+++ b/docs/design/technotes/ws-llm-spike.md
@@ -1,0 +1,84 @@
+# Spike 検証結果: WebSocket + LLM streaming + AbortSignal
+
+Issue [#81](https://github.com/kuairen-227/agent-team-studio/issues/81) の Spike 検証結果。Walking Skeleton (Issue #82) 着手前に、設計前提が実機で成立するかを確認した。
+
+検証コードは [`spike/`](../../../spike/) を参照。
+
+## 検証環境
+
+| 項目 | バージョン |
+| --- | --- |
+| Bun | 1.3.13 |
+| Hono | 4.12.16 |
+| `@anthropic-ai/sdk` | 0.92.0 |
+| 検証日 | 2026-05-03 |
+
+## 検証 1: Hono + Bun の WebSocket
+
+### 検証 1 範囲
+
+`hono/bun` の `upgradeWebSocket` を用いた最小サーバを起動し、3 ケースをクライアントから実行。
+
+### 検証 1 結果
+
+| Case | 内容 | 期待 | 実測 | 判定 |
+| --- | --- | --- | --- | --- |
+| A | 不正な `executionId` (空文字) で接続 | close `4404 execution_not_found` | close `4404 execution_not_found`、サーバ受信メッセージ 0 | ✅ |
+| B | 正常 `executionId` で接続 | 初期スナップショット 5 件 → push 5 件 → `execution:completed` → close `1000` | 11 メッセージ受信 (`agent:status×5`、`agent:output×5`、`execution:completed×1`)、close `1000` | ✅ |
+| C | クライアント主導 `ws.close(1000)` を 3 メッセージ受信後 | サーバ側 `onClose` が発火 | サーバログに `[server] close code=1000` 出力、`onClose` 内 `clearInterval` まで到達 | ✅ |
+
+### 検証 1 と設計前提との整合
+
+- `upgradeWebSocket((c) => { onOpen, onMessage, onClose })` の API で [websocket-design.md §接続ライフサイクル](../websocket-design.md) の主要動作 (ハンドシェイク・初期スナップショット・サーバ push・クライアント切断検知) はすべて実装可能
+- close code 4xxx (アプリケーション定義) も `ws.close(4404, "execution_not_found")` で問題なく送出可能
+- サーバから複数 `ws.send()` を高頻度発行しても順序逆転なし (TCP 順序がそのまま保たれる、[websocket-design.md §メッセージ順序保証](../websocket-design.md) と整合)
+
+### 注意点 (実装時に踏まえる)
+
+- **不正 `executionId` の close タイミング** — `upgradeWebSocket` のコールバックは「アップグレードを受理した後」に `onOpen` が呼ばれる構造。HTTP レイヤで 404 を返すのではなく、WebSocket ハンドシェイク (HTTP 101) 成立直後に close フレーム (4404) を送る挙動になる。クライアントから見ると `WebSocket` の `onclose` が `code=4404` で発火し、`onopen` は発火しない場合と発火直後に close される場合がある (環境依存)。`websocket-design.md` の `close(4404, "execution_not_found")` 表記と機能的には一致するが、HTTP レイヤで弾く実装ではない点を実装メモに残す
+- **`onClose` 内のリソース解放** — push 用の `setInterval` を `onClose` で `clearInterval` する責務はサーバ側に残る。これを怠るとクライアント切断後もタイマが回り続けるリスクあり。Walking Skeleton 実装時は `AbortController` ベースに統一するのが望ましい
+
+## 検証 2: Anthropic SDK streaming + AbortSignal
+
+### 検証 2 範囲
+
+`client.messages.stream(body, { signal })` に `AbortSignal` を渡し、5 ケースを実行。
+
+### 検証 2 結果
+
+| Case | 内容 | 経過 ms | chunk 数 | 例外型 | 判定 |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 外部 `AbortController.abort()` を 500ms 後に呼ぶ | 530 | 0 | `APIUserAbortError` | ✅ 即時中断 (~30ms) |
+| 2 | `MessageStream.abort()` を 5 chunk 受信後に呼ぶ | 1554 | 5 | `APIUserAbortError` | ✅ SDK 経由でも同一例外型 |
+| 3 | `AbortSignal.timeout(1000)` 単体 | 1036 | 2 | `APIUserAbortError` | ✅ Web 標準 timeout signal も即時動作 |
+| 4 | `AbortSignal.any([execution=10s, agent=800ms, llm=120s])` 3 階層合成 | 828 | 0 | `APIUserAbortError` | ✅ 最短 (agent) で当選、~28ms オーバー |
+| 5 | 正常完了 (制御群、`max_tokens=64`) | 760 | 2 | — | ✅ エラーなし、stream 完走 |
+
+### 検証 2 と設計前提との整合
+
+- [agent-execution.md §7 タイムアウト階層](../agent-execution.md) の 3 階層 (LLM 単体 / エージェント単位 / Execution 全体) は **`AbortSignal.any([s1, s2, s3])` で素直に合成可能**。SDK 側に拡張は不要
+- [agent-execution.md §8 キャンセル](../agent-execution.md) の「`AbortSignal` で進行中の LLM 呼び出し (SDK リトライ含む) を中断」は SDK 内蔵の AbortSignal 連動で実現される。独自リトライロジック不要 ([llm-integration.md §リトライの実装方針](../llm-integration.md) の前提を補強)
+- 中断時の例外型は **常に `APIUserAbortError`** で一貫する (外部 `AbortController` 経由・`MessageStream.abort()` 経由・`AbortSignal.timeout()` 経由のいずれも同じ)。`agent-core` 側の例外ハンドラはこの 1 種類を `AgentFailReason: "timeout"` または `"internal_error"` に写像すればよい
+
+### 例外マッピング指針 (実装メモ)
+
+`llm-client.ts` の境界で `APIUserAbortError` を以下の 2 つの内部 reason に写像する:
+
+| 起点 | 写像先 `AgentFailReason` |
+| --- | --- |
+| `AbortSignal.timeout()` または engine が timeout 起点で発行した signal | `"timeout"` |
+| ユーザー / engine からの明示的キャンセル (MVP では未使用) | (該当なし — MVP スコープ外、[agent-execution.md §8](../agent-execution.md)) |
+
+`APIUserAbortError` 自体には起点情報が含まれないため、**起点判定は engine 側で「どの signal が abort されたか」を保持**する必要がある (`AbortSignal.any` で合成した個別 signal の `aborted` プロパティを参照)。
+
+## 既存 design doc への反映
+
+検証の結果、既存 design doc の **設計前提はすべて実機で成立**。本体記述の修正は行わない。
+
+[ADR-0021 ドキュメント間参照ポリシー](../../adr/0021-doc-cross-reference-policy.md) に従い、設計 doc から本 technote への逆参照は付けない（双方向リンクの回避）。本 technote は設計 doc を参照する片方向で接続する。技術ノートとしての発見導線は [docs/design/README.md](../README.md) の `technotes/` 索引に集約する。
+
+## 結論
+
+- WebSocket / LLM streaming / AbortSignal の 3 点とも、`agent-execution.md` / `websocket-design.md` / `llm-integration.md` の設計前提は実機で成立
+- Walking Skeleton (Issue [#82](https://github.com/kuairen-227/agent-team-studio/issues/82)) は本検証コードを参考に、`apps/api`・`packages/agent-core` への正式実装を進める
+- 設計 doc の本体記述変更は不要

--- a/docs/design/technotes/ws-llm-spike.md
+++ b/docs/design/technotes/ws-llm-spike.md
@@ -38,6 +38,12 @@ Issue [#81](https://github.com/kuairen-227/agent-team-studio/issues/81) の Spik
 - **不正 `executionId` の close タイミング** — `upgradeWebSocket` のコールバックは「アップグレードを受理した後」に `onOpen` が呼ばれる構造。HTTP レイヤで 404 を返すのではなく、WebSocket ハンドシェイク (HTTP 101) 成立直後に close フレーム (4404) を送る挙動になる。クライアントから見ると `WebSocket` の `onclose` が `code=4404` で発火し、`onopen` は発火しない場合と発火直後に close される場合がある (環境依存)。`websocket-design.md` の `close(4404, "execution_not_found")` 表記と機能的には一致するが、HTTP レイヤで弾く実装ではない点を実装メモに残す
 - **`onClose` 内のリソース解放** — push 用の `setInterval` を `onClose` で `clearInterval` する責務はサーバ側に残る。これを怠るとクライアント切断後もタイマが回り続けるリスクあり。Walking Skeleton 実装時は `AbortController` ベースに統一するのが望ましい
 
+### 検証範囲外 (Walking Skeleton で確認する項目)
+
+本 Spike では以下は未検証。Walking Skeleton (#82) 実装時に同等の検証を行うこと:
+
+- **不正 `executionId` の他境界** — Case A は空文字のみ確認。クエリパラメータ自体の欠落 (`/ws`)、65 文字、大文字 (`Spike-B`) など正規表現 `^[a-z0-9-]{1,64}$` の他境界は未検証
+
 ## 検証 2: Anthropic SDK streaming + AbortSignal
 
 ### 検証 2 範囲
@@ -70,6 +76,10 @@ Issue [#81](https://github.com/kuairen-227/agent-team-studio/issues/81) の Spik
 | ユーザー / engine からの明示的キャンセル (MVP では未使用) | (該当なし — MVP スコープ外、[agent-execution.md §8](../agent-execution.md)) |
 
 `APIUserAbortError` 自体には起点情報が含まれないため、**起点判定は engine 側で「どの signal が abort されたか」を保持**する必要がある (`AbortSignal.any` で合成した個別 signal の `aborted` プロパティを参照)。
+
+### 検証 2 範囲外 (Walking Skeleton で確認する項目)
+
+- **SDK リトライ中の AbortSignal 中断** — `maxRetries: 3` を設定したが、本 Spike の 5 ケースは初回呼び出し中の中断のみ観測。リトライ待機中 (指数バックオフ中) に AbortSignal が発火した場合の挙動は未検証。Walking Skeleton 実装時に、429 / 5xx 応答をモックしてリトライ待機を発生させ、その間の `AbortSignal.any` 発火が即時中断につながるかを確認すること
 
 ## 既存 design doc への反映
 

--- a/docs/design/technotes/ws-llm-spike.md
+++ b/docs/design/technotes/ws-llm-spike.md
@@ -2,7 +2,7 @@
 
 Issue [#81](https://github.com/kuairen-227/agent-team-studio/issues/81) の Spike 検証結果。Walking Skeleton (Issue #82) 着手前に、設計前提が実機で成立するかを確認した。
 
-検証コードは [`spike/`](../../../spike/) を参照。
+検証コードは [`spike/`](../../../spike/) を参照（Walking Skeleton (#82) 着手時に削除予定のため、本リンクは一時参照）。削除時は本 technote のリンクも削除し「検証コードは Issue #81 / PR #113 の履歴を参照」に書き換える。
 
 ## 検証環境
 

--- a/spike/README.md
+++ b/spike/README.md
@@ -1,0 +1,56 @@
+# spike/
+
+Issue [#81](https://github.com/kuairen-227/agent-team-studio/issues/81) の Spike コード置き場。Walking Skeleton (Issue [#82](https://github.com/kuairen-227/agent-team-studio/issues/82)) 着手時に削除予定。
+
+検証結果のサマリは [docs/design/technotes/ws-llm-spike.md](../docs/design/technotes/ws-llm-spike.md) を参照。
+
+## 位置付け
+
+- 本体ワークスペース (`apps/*` / `packages/*`) には含めない独立ディレクトリ
+- 依存関係は `spike/package.json` に閉じ、`spike/node_modules` で完結する
+- 製品コードに昇格させない (Walking Skeleton 実装時に正式実装を `apps/api` / `packages/agent-core` に書き起こし、本ディレクトリは削除)
+
+## セットアップ
+
+```bash
+cd spike && bun install
+```
+
+LLM spike は Anthropic API を実呼び出しするため `ANTHROPIC_API_KEY` が必要 (リポジトリルートの `.env.example` 参照)。
+
+## 実行
+
+### WebSocket spike
+
+別ターミナルで:
+
+```bash
+cd spike && bun run ws:server   # ターミナル A: サーバ起動 (port 3100)
+cd spike && bun run ws:client   # ターミナル B: 3 ケース連続実行
+```
+
+検証ケース:
+
+| Case | 内容 | 期待結果 |
+| --- | --- | --- |
+| A | 不正な `executionId` で接続 | サーバ側で close `4404 execution_not_found` |
+| B | 正常 `executionId` で接続 | 初期スナップショット (5 件) → push (5 件) → `execution:completed` → close `1000` |
+| C | クライアント主導 close | サーバ側 `onClose` 発火 |
+
+### LLM spike
+
+```bash
+cd spike && ANTHROPIC_API_KEY=... bun run llm
+```
+
+検証ケース:
+
+| Case | 内容 | 期待結果 |
+| --- | --- | --- |
+| 1 | 外部 `AbortController.abort()` (500ms) | `APIUserAbortError` で即時中断 |
+| 2 | `stream.abort()` を 5 chunk 受信後に呼ぶ | `APIUserAbortError` で即時中断 |
+| 3 | `AbortSignal.timeout(1000)` 単体 | `APIUserAbortError` で 1s 経過後中断 |
+| 4 | `AbortSignal.any([execution, agent, llm])` 3 階層合成 | 最短の `agent` (800ms) で当選 |
+| 5 | 正常完了 (制御群) | エラーなし、chunk 受信 |
+
+実コスト概算: Haiku で 5 ケース合計 < $0.001。

--- a/spike/bun.lock
+++ b/spike/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "spike-ws-llm",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.92.0",
+        "hono": "^4.12.15",
+      },
+    },
+  },
+  "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.92.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "hono": ["hono@4.12.16", "", {}, "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+  }
+}

--- a/spike/llm-spike.ts
+++ b/spike/llm-spike.ts
@@ -1,0 +1,178 @@
+// Issue #81 Spike: @anthropic-ai/sdk v0.92 の messages.stream() + AbortSignal を検証。
+// 検証ポイント:
+//   1. AbortSignal を渡し、abort() で即時中断されるか
+//   2. 中断時の例外型 (期待: APIUserAbortError)
+//   3. 3 階層タイムアウト (LLM 単体 / エージェント / Execution 全体) を AbortSignal.any で合成可能か
+//
+// 実行: ANTHROPIC_API_KEY=... bun run llm-spike.ts
+import Anthropic, { APIUserAbortError } from "@anthropic-ai/sdk";
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+if (!apiKey) {
+  console.error("ANTHROPIC_API_KEY is not set");
+  process.exit(1);
+}
+
+const client = new Anthropic({ apiKey, maxRetries: 3 });
+
+// agent-execution.md §7 準拠の値 (Spike 用に短縮)
+const TIMEOUT_LLM_MS = 120_000;
+const TIMEOUT_AGENT_MS = 800; // 本番 300s。Spike では 800ms に短縮し、3 階層中の最短として当選するか観測
+const TIMEOUT_EXECUTION_MS = 10_000; // 本番 1500s。Spike では 10s に短縮
+
+const MODEL = "claude-haiku-4-5-20251001"; // 検証コスト最小化のため Haiku 利用
+const PROMPT =
+  "1 から 200 までの数字を、各行に 1 つずつゆっくり丁寧に説明しながら出力してください。";
+
+type Outcome = {
+  case: string;
+  durationMs: number;
+  chunkCount: number;
+  totalChars: number;
+  errorName: string | null;
+  errorMessage: string | null;
+  isUserAbortError: boolean;
+};
+
+async function streamWithSignal(
+  caseName: string,
+  signal: AbortSignal,
+  chunkLimit?: number,
+): Promise<Outcome> {
+  const start = Date.now();
+  let chunkCount = 0;
+  let totalChars = 0;
+  try {
+    const stream = client.messages.stream(
+      {
+        model: MODEL,
+        max_tokens: 2048,
+        temperature: 0.3,
+        messages: [{ role: "user", content: PROMPT }],
+      },
+      { signal },
+    );
+    for await (const event of stream) {
+      if (
+        event.type === "content_block_delta" &&
+        event.delta.type === "text_delta"
+      ) {
+        chunkCount += 1;
+        totalChars += event.delta.text.length;
+        if (chunkLimit && chunkCount >= chunkLimit) {
+          // SDK 自身の abort() メソッドの動作も併せて確認
+          stream.abort();
+        }
+      }
+    }
+    return {
+      case: caseName,
+      durationMs: Date.now() - start,
+      chunkCount,
+      totalChars,
+      errorName: null,
+      errorMessage: null,
+      isUserAbortError: false,
+    };
+  } catch (err) {
+    const e = err as Error;
+    return {
+      case: caseName,
+      durationMs: Date.now() - start,
+      chunkCount,
+      totalChars,
+      errorName: e.constructor.name,
+      errorMessage: e.message,
+      isUserAbortError: err instanceof APIUserAbortError,
+    };
+  }
+}
+
+const results: Outcome[] = [];
+
+// --- Case 1: AbortController.abort() で外部中断 (~500ms 後)
+console.log("=== Case 1: external AbortController.abort() ===");
+{
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), 500);
+  results.push(await streamWithSignal("1:external-abort", ac.signal));
+  clearTimeout(timer);
+}
+
+// --- Case 2: stream.abort() で SDK 経由の中断 (5 chunk 受信後)
+console.log("=== Case 2: stream.abort() after 5 chunks ===");
+{
+  const ac = new AbortController();
+  results.push(await streamWithSignal("2:stream-abort-after-5", ac.signal, 5));
+}
+
+// --- Case 3: AbortSignal.timeout() による単体タイムアウト (1s)
+console.log("=== Case 3: AbortSignal.timeout(1000) ===");
+results.push(
+  await streamWithSignal("3:signal-timeout-1s", AbortSignal.timeout(1000)),
+);
+
+// --- Case 4: 3 階層 AbortSignal.any 合成 (Execution / Agent / LLM 単体)
+//   - 最も短い AGENT signal が当選することを確認
+console.log("=== Case 4: layered AbortSignal.any (3 layers) ===");
+{
+  const executionSignal = AbortSignal.timeout(TIMEOUT_EXECUTION_MS);
+  const agentSignal = AbortSignal.timeout(TIMEOUT_AGENT_MS); // 最短: ここで abort されるはず
+  const llmSignal = AbortSignal.timeout(TIMEOUT_LLM_MS);
+  const composed = AbortSignal.any([executionSignal, agentSignal, llmSignal]);
+  results.push(await streamWithSignal("4:any-3layers", composed));
+}
+
+// --- Case 5: 正常完了 (制御群: タイムアウトを大きく取り abort なし)
+console.log(
+  "=== Case 5: normal completion (control, max_tokens=64 で短縮) ===",
+);
+{
+  const start = Date.now();
+  let chunkCount = 0;
+  let totalChars = 0;
+  let errorName: string | null = null;
+  let errorMessage: string | null = null;
+  try {
+    const stream = client.messages.stream({
+      model: MODEL,
+      max_tokens: 64,
+      temperature: 0.3,
+      messages: [{ role: "user", content: "hello を 3 回繰り返して" }],
+    });
+    for await (const event of stream) {
+      if (
+        event.type === "content_block_delta" &&
+        event.delta.type === "text_delta"
+      ) {
+        chunkCount += 1;
+        totalChars += event.delta.text.length;
+      }
+    }
+  } catch (err) {
+    const e = err as Error;
+    errorName = e.constructor.name;
+    errorMessage = e.message;
+  }
+  results.push({
+    case: "5:normal-completion",
+    durationMs: Date.now() - start,
+    chunkCount,
+    totalChars,
+    errorName,
+    errorMessage,
+    isUserAbortError: false,
+  });
+}
+
+console.log("\n=== Summary ===");
+console.table(
+  results.map((r) => ({
+    case: r.case,
+    ms: r.durationMs,
+    chunks: r.chunkCount,
+    chars: r.totalChars,
+    errorName: r.errorName ?? "-",
+    isUserAbortError: r.isUserAbortError,
+  })),
+);

--- a/spike/llm-spike.ts
+++ b/spike/llm-spike.ts
@@ -59,7 +59,7 @@ async function streamWithSignal(
       ) {
         chunkCount += 1;
         totalChars += event.delta.text.length;
-        if (chunkLimit && chunkCount >= chunkLimit) {
+        if (chunkLimit !== undefined && chunkCount >= chunkLimit) {
           // SDK 自身の abort() メソッドの動作も併せて確認
           stream.abort();
         }

--- a/spike/package.json
+++ b/spike/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "spike-ws-llm",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Issue #81: WebSocket + LLM streaming + AbortSignal 検証用のローカル Spike。Walking Skeleton (#82) 実装後に削除予定",
+  "scripts": {
+    "ws:server": "bun run ws-server.ts",
+    "ws:client": "bun run ws-client.ts",
+    "llm": "bun run llm-spike.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.92.0",
+    "hono": "^4.12.15"
+  }
+}

--- a/spike/tsconfig.json
+++ b/spike/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["*.ts"]
+}

--- a/spike/ws-client.ts
+++ b/spike/ws-client.ts
@@ -48,7 +48,11 @@ function runCase(
         durationMs: Date.now() - start,
       });
     };
-    ws.onerror = (e) => reject(new Error(`ws error: ${String(e)}`));
+    ws.onerror = (e) => {
+      const detail =
+        e instanceof ErrorEvent ? e.message : `event type=${e.type}`;
+      reject(new Error(`ws error: ${detail}`));
+    };
   });
 }
 

--- a/spike/ws-client.ts
+++ b/spike/ws-client.ts
@@ -1,0 +1,76 @@
+// Issue #81 Spike: ws-server.ts に対する検証クライアント。
+// 3 ケースを連続実行し、サーバ側のログと突き合わせる:
+//   A. 不正な executionId (close 4404 を確認)
+//   B. 正常接続 → サーバ主導で全 push 受信後 close 1000
+//   C. 正常接続 → 受信途中でクライアント主導 close (サーバの onClose 発火を確認)
+const PORT = Number.parseInt(process.env.PORT ?? "", 10) || 3100;
+const URL = `ws://localhost:${PORT}/ws`;
+
+type CaseResult = {
+  name: string;
+  receivedTypes: string[];
+  closeCode: number;
+  closeReason: string;
+  durationMs: number;
+};
+
+function runCase(
+  name: string,
+  url: string,
+  closeAfterMessages?: number,
+): Promise<CaseResult> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const ws = new WebSocket(url);
+    const receivedTypes: string[] = [];
+    let received = 0;
+    ws.onmessage = (e) => {
+      try {
+        const msg = JSON.parse(String(e.data));
+        receivedTypes.push(msg.type);
+      } catch {
+        receivedTypes.push("<non-json>");
+      }
+      received += 1;
+      if (closeAfterMessages !== undefined && received >= closeAfterMessages) {
+        console.log(
+          `[client:${name}] closing client-side after ${received} msgs`,
+        );
+        ws.close(1000, "client_done");
+      }
+    };
+    ws.onclose = (e) => {
+      resolve({
+        name,
+        receivedTypes,
+        closeCode: e.code,
+        closeReason: e.reason,
+        durationMs: Date.now() - start,
+      });
+    };
+    ws.onerror = (e) => reject(new Error(`ws error: ${String(e)}`));
+  });
+}
+
+const results: CaseResult[] = [];
+
+console.log("=== Case A: invalid executionId ===");
+results.push(await runCase("A:invalid", `${URL}?executionId=`));
+
+console.log("=== Case B: normal full receive ===");
+results.push(await runCase("B:normal-full", `${URL}?executionId=spike-b`));
+
+console.log("=== Case C: client-initiated close mid-stream ===");
+results.push(await runCase("C:client-close", `${URL}?executionId=spike-c`, 3));
+
+console.log("\n=== Summary ===");
+console.table(
+  results.map((r) => ({
+    case: r.name,
+    closeCode: r.closeCode,
+    closeReason: r.closeReason,
+    msgCount: r.receivedTypes.length,
+    types: r.receivedTypes.join(","),
+    ms: r.durationMs,
+  })),
+);

--- a/spike/ws-client.ts
+++ b/spike/ws-client.ts
@@ -4,7 +4,7 @@
 //   B. 正常接続 → サーバ主導で全 push 受信後 close 1000
 //   C. 正常接続 → 受信途中でクライアント主導 close (サーバの onClose 発火を確認)
 const PORT = Number.parseInt(process.env.PORT ?? "", 10) || 3100;
-const URL = `ws://localhost:${PORT}/ws`;
+const BASE_URL = `ws://localhost:${PORT}/ws`;
 
 type CaseResult = {
   name: string;
@@ -55,13 +55,15 @@ function runCase(
 const results: CaseResult[] = [];
 
 console.log("=== Case A: invalid executionId ===");
-results.push(await runCase("A:invalid", `${URL}?executionId=`));
+results.push(await runCase("A:invalid", `${BASE_URL}?executionId=`));
 
 console.log("=== Case B: normal full receive ===");
-results.push(await runCase("B:normal-full", `${URL}?executionId=spike-b`));
+results.push(await runCase("B:normal-full", `${BASE_URL}?executionId=spike-b`));
 
 console.log("=== Case C: client-initiated close mid-stream ===");
-results.push(await runCase("C:client-close", `${URL}?executionId=spike-c`, 3));
+results.push(
+  await runCase("C:client-close", `${BASE_URL}?executionId=spike-c`, 3),
+);
 
 console.log("\n=== Summary ===");
 console.table(

--- a/spike/ws-server.ts
+++ b/spike/ws-server.ts
@@ -1,0 +1,94 @@
+// Issue #81 Spike: hono/bun の upgradeWebSocket を最小構成で起動。
+// 検証ポイント:
+//   1. /ws?executionId=<id> でハンドシェイクが成立する
+//   2. 不正な executionId に対し close(4404) で切断できる
+//   3. サーバから push が可能 (擬似 AgentEvent を 5 件送信)
+//   4. クライアント切断時に onClose が発火する
+
+import type { ServerWebSocket } from "bun";
+import { Hono } from "hono";
+import { createBunWebSocket } from "hono/bun";
+
+const { upgradeWebSocket, websocket } = createBunWebSocket<ServerWebSocket>();
+
+const app = new Hono();
+
+app.get("/health", (c) => c.json({ status: "ok" }));
+
+app.get(
+  "/ws",
+  upgradeWebSocket((c) => {
+    const executionId = c.req.query("executionId");
+    let pushTimer: ReturnType<typeof setInterval> | null = null;
+    return {
+      onOpen(_event, ws) {
+        // websocket-design.md §接続ライフサイクル: executionId が不正なら close(4404)
+        if (!executionId || !/^[a-z0-9-]{1,64}$/.test(executionId)) {
+          console.log("[server] reject: invalid executionId");
+          ws.close(4404, "execution_not_found");
+          return;
+        }
+        console.log(`[server] open executionId=${executionId}`);
+        // 初期スナップショット: agent:status x 5 を送信
+        for (const agentId of [
+          "investigation:strategy",
+          "investigation:product",
+          "investigation:investment",
+          "investigation:partnership",
+          "integration:matrix",
+        ]) {
+          ws.send(
+            JSON.stringify({
+              type: "agent:status",
+              agentId,
+              status: "pending",
+              timestamp: new Date().toISOString(),
+            }),
+          );
+        }
+        // 擬似的な AgentEvent push (200ms 間隔で 5 件 → 完了通知)
+        let count = 0;
+        pushTimer = setInterval(() => {
+          count += 1;
+          if (count <= 5) {
+            ws.send(
+              JSON.stringify({
+                type: "agent:output",
+                agentId: "investigation:strategy",
+                chunk: `chunk-${count} `,
+              }),
+            );
+          } else {
+            ws.send(
+              JSON.stringify({
+                type: "execution:completed",
+                executionId,
+                resultId: "result-spike-1",
+              }),
+            );
+            ws.close(1000, "normal");
+            if (pushTimer) clearInterval(pushTimer);
+          }
+        }, 200);
+      },
+      onMessage(event, _ws) {
+        console.log(`[server] message: ${event.data}`);
+      },
+      onClose(event, _ws) {
+        console.log(
+          `[server] close code=${event.code} reason="${event.reason}"`,
+        );
+        if (pushTimer) clearInterval(pushTimer);
+      },
+    };
+  }),
+);
+
+const port = Number.parseInt(process.env.PORT ?? "", 10) || 3100;
+console.log(`[server] listening on http://localhost:${port}`);
+
+export default {
+  port,
+  fetch: app.fetch,
+  websocket,
+};

--- a/spike/ws-server.ts
+++ b/spike/ws-server.ts
@@ -67,6 +67,8 @@ app.get(
               }),
             );
             ws.close(1000, "normal");
+            // onClose でも clearInterval するが、正常終了パスでは setInterval コールバック内で
+            // 即時解放しておくことで「次の tick で push を試みて失敗する」状態を避ける
             if (pushTimer) clearInterval(pushTimer);
           }
         }, 200);


### PR DESCRIPTION
## What

Issue #81 の Spike として、MVP 実装の設計前提のうち実行時挙動が未検証だった 2 点を実機で疎通確認した。

- **`spike/ws-server.ts` + `spike/ws-client.ts`**: `hono/bun` の `upgradeWebSocket` でハンドシェイク・サーバ push・`onClose` 発火・close code 4xxx を検証
- **`spike/llm-spike.ts`**: `@anthropic-ai/sdk` v0.92 の `messages.stream()` に AbortSignal を渡し、即時中断・例外型 (`APIUserAbortError`) 一本化・3 階層 `AbortSignal.any` 合成を検証
- **`docs/design/technotes/ws-llm-spike.md`**: 検証結果のサマリと実装メモ
- **`docs/design/README.md`**: `technotes/` 索引エントリ追加

## Why

closes #81

Walking Skeleton (#82) 着手前に、`agent-execution.md §7/§8` / `websocket-design.md §接続ライフサイクル` / `llm-integration.md` の設計前提が実機で成立するかを決着させる必要があった。

## How

### 検証結果

| 項目 | 結果 |
| --- | --- |
| Hono + Bun WebSocket (3 ケース: 不正 executionId / 正常 / クライアント主導 close) | すべて期待通り |
| LLM streaming + AbortSignal (5 ケース: 外部 abort / SDK abort / signal.timeout / 3 階層 any / 正常完了) | すべて期待通り。中断は ~30ms 以内に伝播 |
| 中断時の例外型 | すべて `APIUserAbortError` に正規化 |
| 3 階層タイムアウト | `AbortSignal.any([execution, agent, llm])` で素直に合成可能 |

### 設計 doc への影響

設計前提はすべて成立したため `agent-execution.md` / `websocket-design.md` / `llm-integration.md` の本体記述変更は **不要**。

ADR-0021 (双方向リンク回避) に従い、設計 doc から technote への逆参照は付けず `docs/design/README.md` の `technotes/` 索引で導線を集約する方針とした。

### spike/ の扱い

`spike/` は workspaces 外の独立パッケージ。Walking Skeleton (#82) 着手時に削除予定 (本体実装は `apps/api`・`packages/agent-core` に書き起こす)。

## Checklist

- [x] `bun run lint:md` が通ること
- [x] `bun run lint` / `lint:secret` / `type-check` / `test` が通ること (pre-commit hook で確認)
- [x] 検証結果を docs に記録したこと