### PR TITLE
chore(project): lint:fix スクリプトを turbo 経由で追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ CLAUDE.md は AI が常時参照する起動時ガイダンスとして要点を
 | コマンド | 説明 |
 | --- | --- |
 | `bun run lint` | Biome による静的解析（全ワークスペース、Turborepo 経由） |
+| `bun run lint:fix` | Biome による自動修正（全ワークスペース、Turborepo 経由） |
 | `bun run lint:md` | Markdown の lint（markdownlint-cli2） |
 | `bun run lint:secret` | 機密情報の検出（secretlint） |
 | `bun run type-check` | TypeScript 型チェック（全ワークスペース、Turborepo 経由） |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ CLAUDE.md は AI が常時参照する起動時ガイダンスとして要点を
 | コマンド | 説明 |
 | --- | --- |
 | `bun run lint` | Biome による静的解析（全ワークスペース、Turborepo 経由） |
-| `bun run lint:fix` | Biome による自動修正（全ワークスペース、Turborepo 経由） |
+| `bun run lint:fix` | Biome による lint・format の自動修正（全ワークスペース、Turborepo 経由） |
 | `bun run lint:md` | Markdown の lint（markdownlint-cli2） |
 | `bun run lint:secret` | 機密情報の検出（secretlint） |
 | `bun run type-check` | TypeScript 型チェック（全ワークスペース、Turborepo 経由） |

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "lint": "biome check src/",
+    "lint:fix": "biome check --write src/",
     "type-check": "tsc --noEmit",
     "test": "bun test"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "biome check src/ vite.config.ts",
+    "lint:fix": "biome check --write src/ vite.config.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "turbo run dev",
     "lint": "turbo run lint",
+    "lint:fix": "turbo run lint:fix",
     "lint:md": "markdownlint-cli2",
     "lint:secret": "secretlint '**/*'",
     "type-check": "turbo run type-check",

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "lint": "biome check src/",
+    "lint:fix": "biome check --write src/",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "lint": "biome check src/",
+    "lint:fix": "biome check --write src/",
     "type-check": "tsc --noEmit",
     "test": "bun test",
     "db:generate": "drizzle-kit generate",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "lint": "biome check src/",
+    "lint:fix": "biome check --write src/",
     "type-check": "tsc --noEmit",
     "test": "bun test"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,9 @@
       "env": ["DATABASE_URL", "PORT"]
     },
     "lint": {},
+    "lint:fix": {
+      "cache": false
+    },
     "type-check": {},
     "test": {},
     "build": {


### PR DESCRIPTION
## What

Biome の自動修正コマンド (`biome check --write`) を `lint:fix` スクリプトとして全ワークスペースおよびルートに登録し、Turborepo 経由で実行できるようにする。

- 各ワークスペース (`apps/api`, `apps/web`, `packages/agent-core`, `packages/db`, `packages/shared`) に `lint:fix` を追加
- ルート `package.json` に `lint:fix: turbo run lint:fix` を追加
- `turbo.json` に `lint:fix` タスクを登録（`cache: false`）
- CLAUDE.md の主要コマンド表に追記

## Why

Biome 自動修正をワークスペース横断で統一的に呼び出せるようにするため。既存の `lint` と対称なエントリポイントを用意することで、CI や hooks からの呼び出しを揃えやすくする。

`--write` は副作用を伴うため Turbo キャッシュとは相性が悪く、`cache: false` を明示している。

## How

軽微な変更のため省略。

## Checklist

- [x] テストが通ること（`bun run lint:fix` で 5 ワークスペースが成功することを確認済）
- [x] ドキュメントを更新したこと（CLAUDE.md 主要コマンド表に追記）