### PR TITLE
chore(project): allow gh pr edit for label/assignee operations

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,6 +42,7 @@
       "Bash(gh milestone list:*)",
       "Bash(gh pr create:*)",
       "Bash(gh pr comment:*)",
+      "Bash(gh pr edit:*)",
       "Bash(gh pr diff:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)"


### PR DESCRIPTION
## What

`.claude/settings.json` の `permissions.allow` に `Bash(gh pr edit:*)` を追加する。

## Why

PR #128 作成時に GitHub API の 502 で `gh pr create --label / --assignee` がラベル/assignee 付与に失敗した。リトライ手段として `gh pr edit --add-label / --add-assignee` を使う運用に至ったが、この権限が無いと毎回 deny されてしまう。

## How

軽微な権限追加 1 行のみ。

## Checklist

- [x] テストが通ること（該当する場合）— 設定変更のため code 検証なし、`bun run lint:secret` 緑
- [x] ドキュメントを更新したこと（該当する場合）— 設定変更のため doc 更新なし