### PR TITLE
feat(web): US-2 調査パラメータを入力して実行する #118

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
     "@agent-team-studio/agent-core": "workspace:*",
     "@agent-team-studio/db": "workspace:*",
     "@agent-team-studio/shared": "workspace:*",
-    "hono": "^4.12.15"
+    "hono": "^4.12.15",
+    "zod": "^4.3.6"
   }
 }

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -222,5 +222,8 @@ describe("POST /api/executions", () => {
     expect(res.status).toBe(500);
     const body = (await res.json()) as ApiInternalError;
     expect(body.errorCode).toBe("internal_error");
+    expect(body.message).toBeTruthy();
+    // 内部例外メッセージが API レスポンスに漏洩しないことを境界として固定する。
+    expect(body.message).not.toContain("DB connection failed");
   });
 });

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import type {
   ApiInternalError,
   ApiNotFoundError,
+  ApiValidationError,
+  CompetitorAnalysisParameters,
+  CreateExecutionResponse,
   GetTemplateResponse,
   GetTemplatesResponse,
 } from "@agent-team-studio/shared";
@@ -12,7 +15,23 @@ const buildApp = (overrides: Partial<AppDeps> = {}) =>
   createApp({
     listTemplateSummaries: async () => [],
     getTemplateById: async () => null,
+    createExecution: async () => ({
+      id: "exec-1",
+      status: "pending",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    }),
     ...overrides,
+  });
+
+const validParameters: CompetitorAnalysisParameters = {
+  competitors: ["Acme"],
+};
+
+const postExecutions = (app: ReturnType<typeof buildApp>, body: unknown) =>
+  app.request("/api/executions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
   });
 
 describe("GET /api/templates", () => {
@@ -91,5 +110,100 @@ describe("GET /api/templates/:id", () => {
     const body = (await res.json()) as ApiInternalError;
     expect(body.errorCode).toBe("internal_error");
     expect(body.message).toBeTruthy();
+  });
+});
+
+describe("POST /api/executions", () => {
+  test("正常系は 202 + CreateExecutionResponse 形を返す", async () => {
+    const app = buildApp({
+      getTemplateById: async () => fixtureTemplate,
+      createExecution: async () => ({
+        id: "exec-1",
+        status: "pending",
+        createdAt: "2026-05-04T00:00:00.000Z",
+      }),
+    });
+
+    const res = await postExecutions(app, {
+      templateId: fixtureTemplate.id,
+      parameters: validParameters,
+    });
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as CreateExecutionResponse;
+    expect(body).toEqual({
+      id: "exec-1",
+      status: "pending",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+  });
+
+  test("Template 不在は 404 + ApiNotFoundError 形を返す", async () => {
+    const app = buildApp({ getTemplateById: async () => null });
+
+    const res = await postExecutions(app, {
+      templateId: "tpl-missing",
+      parameters: validParameters,
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as ApiNotFoundError;
+    expect(body.errorCode).toBe("not_found");
+    expect(body.details).toEqual({ resource: "template", id: "tpl-missing" });
+  });
+
+  test("バリデーション失敗は 400 + ApiValidationError 形を返す", async () => {
+    const app = buildApp({ getTemplateById: async () => fixtureTemplate });
+
+    const res = await postExecutions(app, {
+      templateId: fixtureTemplate.id,
+      parameters: { competitors: [] },
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiValidationError;
+    expect(body.errorCode).toBe("validation_error");
+    expect(body.details.length).toBeGreaterThan(0);
+    expect(body.details[0]).toHaveProperty("field");
+    expect(body.details[0]).toHaveProperty("reason");
+  });
+
+  // route 層独自のエラー整形契約として field 名（"body"）まで明示する。
+  // 本ケースは route 内 c.req.json() の throw 経路で、service 層の検証では再現できない。
+  test("body が JSON でない場合は field='body' の ApiValidationError を返す", async () => {
+    const app = buildApp();
+
+    const res = await app.request("/api/executions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-json",
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiValidationError;
+    expect(body.errorCode).toBe("validation_error");
+    expect(body.details).toEqual([
+      { field: "body", reason: expect.any(String) },
+    ]);
+  });
+
+  // onError ミドルウェアが ApiInternalError 形に整形する境界を検証する。
+  // service 層の同種テストは「例外を握りつぶさず透過させる」契約を扱う（責務分担）。
+  test("createExecution が例外を投げると 500 + ApiInternalError 形を返す", async () => {
+    const app = buildApp({
+      getTemplateById: async () => fixtureTemplate,
+      createExecution: async () => {
+        throw new Error("DB connection failed");
+      },
+    });
+
+    const res = await postExecutions(app, {
+      templateId: fixtureTemplate.id,
+      parameters: validParameters,
+    });
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as ApiInternalError;
+    expect(body.errorCode).toBe("internal_error");
   });
 });

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -64,6 +64,7 @@ describe("GET /api/templates", () => {
     const body = (await res.json()) as ApiInternalError;
     expect(body.errorCode).toBe("internal_error");
     expect(body.message).toBeTruthy();
+    expect(body.message).not.toContain("DB connection failed");
   });
 });
 
@@ -110,6 +111,7 @@ describe("GET /api/templates/:id", () => {
     const body = (await res.json()) as ApiInternalError;
     expect(body.errorCode).toBe("internal_error");
     expect(body.message).toBeTruthy();
+    expect(body.message).not.toContain("DB connection failed");
   });
 });
 

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -152,6 +152,8 @@ describe("POST /api/executions", () => {
     expect(body.details).toEqual({ resource: "template", id: "tpl-missing" });
   });
 
+  // route 層を経由した validation_error の整形のみを検証する。
+  // 個別 field 名・境界値は service 層テスト（services/executions.test.ts）に委譲する。
   test("バリデーション失敗は 400 + ApiValidationError 形を返す", async () => {
     const app = buildApp({ getTemplateById: async () => fixtureTemplate });
 
@@ -166,6 +168,21 @@ describe("POST /api/executions", () => {
     expect(body.details.length).toBeGreaterThan(0);
     expect(body.details[0]).toHaveProperty("field");
     expect(body.details[0]).toHaveProperty("reason");
+  });
+
+  // route 層が `as CreateExecutionRequest` でキャストした後に service の Zod が
+  // `safeParse(undefined)` で受け止める経路を明示的に押さえる。
+  test("parameters フィールド省略は 400 + ApiValidationError 形を返す", async () => {
+    const app = buildApp({ getTemplateById: async () => fixtureTemplate });
+
+    const res = await postExecutions(app, {
+      templateId: fixtureTemplate.id,
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiValidationError;
+    expect(body.errorCode).toBe("validation_error");
+    expect(body.details.length).toBeGreaterThan(0);
   });
 
   // route 層独自のエラー整形契約として field 名（"body"）まで明示する。

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,16 +11,26 @@
  * エラーは `lib/errors.ts` の onError で `ApiNotFoundError` / `ApiInternalError` 形に整形する。
  */
 
-import type { Template, TemplateSummary } from "@agent-team-studio/shared";
+import type { CreateExecutionInput } from "@agent-team-studio/db";
+import type {
+  CreateExecutionResponse,
+  Template,
+  TemplateSummary,
+} from "@agent-team-studio/shared";
 import { Hono } from "hono";
 import { onError } from "./lib/errors.ts";
+import { createExecutionsRoutes } from "./routes/executions.ts";
 import { createTemplatesRoutes } from "./routes/templates.ts";
 import { createWsRoutes } from "./routes/ws.ts";
+import { createExecutionsService } from "./services/executions.ts";
 import { createTemplatesService } from "./services/templates.ts";
 
 export type AppDeps = {
   listTemplateSummaries: () => Promise<TemplateSummary[]>;
   getTemplateById: (id: string) => Promise<Template | null>;
+  createExecution: (
+    input: CreateExecutionInput,
+  ) => Promise<CreateExecutionResponse>;
 };
 
 export function createApp(deps: AppDeps) {
@@ -35,6 +45,13 @@ export function createApp(deps: AppDeps) {
     getTemplateById: deps.getTemplateById,
   });
   app.route("/api/templates", createTemplatesRoutes({ templatesService }));
+
+  const executionsService = createExecutionsService({
+    getTemplateById: deps.getTemplateById,
+    createExecution: deps.createExecution,
+  });
+  app.route("/api/executions", createExecutionsRoutes({ executionsService }));
+
   app.route("/ws", createWsRoutes());
 
   return app;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -13,6 +13,10 @@ import type {
 } from "@agent-team-studio/shared";
 import { Hono } from "hono";
 import { onError } from "./lib/errors.ts";
+// API モジュール全体で Zod のロケールを日本語に統一する副作用 import。
+// 個別 service ではなく app.ts で一括設定し、新しい service が追加されても
+// import 順に依存しないようにする。
+import "./lib/zod-config.ts";
 import { createExecutionsRoutes } from "./routes/executions.ts";
 import { createTemplatesRoutes } from "./routes/templates.ts";
 import { createWsRoutes } from "./routes/ws.ts";

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,14 +1,8 @@
 /**
  * Hono app の組み立て。
  *
- * `index.ts` から本番の DB クライアントを渡して起動するパスと、
- * `app.test.ts` から fake repo を渡して `app.request()` で叩くパスを共通化するため、
- * app の構築を関数として切り出す。
- *
- * 依存（templates の repo 関数）は引数で受け取り、内部で service を生成する。
- * route → service → repo の 3 層を貫通する点は ADR-0010 開発ワークフローに準拠。
- *
- * エラーは `lib/errors.ts` の onError で `ApiNotFoundError` / `ApiInternalError` 形に整形する。
+ * 依存（repo 関数）を引数で受け取ることで、本番起動と fake repo を使ったテストの
+ * 起動パスを共通化する。
  */
 
 import type { CreateExecutionInput } from "@agent-team-studio/db";

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,6 +9,7 @@
 
 import {
   createDbClient,
+  createExecution,
   getTemplateById,
   listTemplateSummaries,
 } from "@agent-team-studio/db";
@@ -25,6 +26,7 @@ const { db } = createDbClient(databaseUrl);
 const app = createApp({
   listTemplateSummaries: () => listTemplateSummaries(db),
   getTemplateById: (id) => getTemplateById(db, id),
+  createExecution: (input) => createExecution(db, input),
 });
 
 const port = Number.parseInt(process.env.PORT ?? "", 10) || 3000;

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -1,8 +1,8 @@
 /**
  * REST エラーの内部表現と onError ミドルウェア。
  *
- * Service / Route 層は `NotFoundError` を throw し、`onError` ハンドラで
- * `ApiNotFoundError` 形（`packages/shared/src/api-types.ts`）+ HTTP 404 に整形する。
+ * Service / Route 層は `NotFoundError` / `ValidationError` を throw し、`onError`
+ * ハンドラで `ApiNotFoundError` / `ApiValidationError` 形（`packages/shared/src/api-types.ts`）+ HTTP に整形する。
  *
  * 内部例外（DB 接続失敗等）は `internal_error` (500) として `ApiInternalError` に
  * 整形する。詳細漏洩を避けるため `details` は MVP では返さない（api-design.md §エラーレスポンス）。
@@ -11,6 +11,7 @@
 import type {
   ApiInternalError,
   ApiNotFoundError,
+  ApiValidationError,
 } from "@agent-team-studio/shared";
 import type { ErrorHandler } from "hono";
 
@@ -25,6 +26,16 @@ export class NotFoundError extends Error {
   }
 }
 
+export class ValidationError extends Error {
+  constructor(
+    readonly details: ApiValidationError["details"],
+    message?: string,
+  ) {
+    super(message ?? "validation failed");
+    this.name = "ValidationError";
+  }
+}
+
 const NOT_FOUND_MESSAGES: Record<
   ApiNotFoundError["details"]["resource"],
   string
@@ -34,6 +45,15 @@ const NOT_FOUND_MESSAGES: Record<
 };
 
 export const onError: ErrorHandler = (err, c) => {
+  if (err instanceof ValidationError) {
+    const body: ApiValidationError = {
+      errorCode: "validation_error",
+      message: "入力に誤りがあります",
+      details: err.details,
+    };
+    return c.json(body, 400);
+  }
+
   if (err instanceof NotFoundError) {
     const body: ApiNotFoundError = {
       errorCode: "not_found",

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -2,10 +2,8 @@
  * REST エラーの内部表現と onError ミドルウェア。
  *
  * Service / Route 層は `NotFoundError` / `ValidationError` を throw し、`onError`
- * ハンドラで `ApiNotFoundError` / `ApiValidationError` 形（`packages/shared/src/api-types.ts`）+ HTTP に整形する。
- *
- * 内部例外（DB 接続失敗等）は `internal_error` (500) として `ApiInternalError` に
- * 整形する。詳細漏洩を避けるため `details` は MVP では返さない（api-design.md §エラーレスポンス）。
+ * ハンドラで API レスポンス形 + HTTP ステータスに整形する。内部例外（DB 接続失敗等）は
+ * `internal_error` (500) に集約し、詳細漏洩を避けるため `details` は返さない。
  */
 
 import type {

--- a/apps/api/src/lib/zod-config.ts
+++ b/apps/api/src/lib/zod-config.ts
@@ -1,0 +1,12 @@
+/**
+ * Zod の組み込み日本語ロケールを適用する副作用モジュール。
+ * import するだけで `z.config(ja())` が実行される。
+ *
+ * lib/errors.ts の他エラーが日本語固定なのと整合させ、Zod のデフォルト英語メッセージが
+ * `ApiValidationError.details[].reason` に漏れるのを防ぐ。
+ */
+
+import { z } from "zod";
+import { ja } from "zod/locales";
+
+z.config(ja());

--- a/apps/api/src/routes/executions.ts
+++ b/apps/api/src/routes/executions.ts
@@ -1,0 +1,42 @@
+/**
+ * `POST /api/executions` ルート。
+ *
+ * Service を引数で受け取り（DI）、Hono の `c.req.json()` で受信した body をそのまま
+ * service へ渡す。body の構造妥当性（templateId / parameters の存在）は service 側の
+ * Zod で検証する。
+ *
+ * JSON parse 失敗（壊れた body）は `ValidationError` に整形して 400 を返す。
+ *
+ * 成功時は 202 Accepted（api-design.md §HTTP メソッド 非同期処理開始）。
+ */
+
+import type {
+  CreateExecutionRequest,
+  CreateExecutionResponse,
+} from "@agent-team-studio/shared";
+import { Hono } from "hono";
+import { ValidationError } from "../lib/errors.ts";
+import type { ExecutionsService } from "../services/executions.ts";
+
+export function createExecutionsRoutes(deps: {
+  executionsService: ExecutionsService;
+}) {
+  const app = new Hono();
+
+  app.post("/", async (c) => {
+    let body: CreateExecutionRequest;
+    try {
+      body = (await c.req.json()) as CreateExecutionRequest;
+    } catch {
+      throw new ValidationError([
+        { field: "body", reason: "リクエスト本文が JSON として不正です" },
+      ]);
+    }
+
+    const result: CreateExecutionResponse =
+      await deps.executionsService.createExecution(body);
+    return c.json(result, 202);
+  });
+
+  return app;
+}

--- a/apps/api/src/routes/executions.ts
+++ b/apps/api/src/routes/executions.ts
@@ -1,13 +1,8 @@
 /**
  * `POST /api/executions` ルート。
  *
- * Service を引数で受け取り（DI）、Hono の `c.req.json()` で受信した body をそのまま
- * service へ渡す。body の構造妥当性（templateId / parameters の存在）は service 側の
- * Zod で検証する。
- *
- * JSON parse 失敗（壊れた body）は `ValidationError` に整形して 400 を返す。
- *
- * 成功時は 202 Accepted（api-design.md §HTTP メソッド 非同期処理開始）。
+ * body の構造検証は service 側の Zod に委譲する。route 層は JSON parse 失敗のみ
+ * `ValidationError` に整形して 400 を返す（field="body" で識別）。成功時は 202 Accepted。
  */
 
 import type {

--- a/apps/api/src/services/executions.test.ts
+++ b/apps/api/src/services/executions.test.ts
@@ -129,6 +129,23 @@ describe("createExecutionsService.createExecution", () => {
     expect(res.id).toBe("exec-1");
   });
 
+  test("competitors の要素が 101 文字（境界 NG）なら ValidationError", async () => {
+    const service = buildService();
+
+    const err = await service
+      .createExecution({
+        templateId: fixtureTemplate.id,
+        parameters: { competitors: ["a".repeat(101)] },
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ValidationError);
+    const validation = err as ValidationError;
+    expect(
+      validation.details.some((d) => d.field.startsWith("competitors")),
+    ).toBe(true);
+  });
+
   test("空文字の competitor を含むと ValidationError", async () => {
     const service = buildService();
 

--- a/apps/api/src/services/executions.test.ts
+++ b/apps/api/src/services/executions.test.ts
@@ -107,6 +107,18 @@ describe("createExecutionsService.createExecution", () => {
     );
   });
 
+  // MVP では重複チェックなし。将来 .refine(unique) を追加するなら破壊的変更となる前提を固定する。
+  test("competitors の重複は許容される", async () => {
+    const service = buildService();
+
+    const res = await service.createExecution({
+      templateId: fixtureTemplate.id,
+      parameters: { competitors: ["Acme", "Acme"] },
+    });
+
+    expect(res.id).toBe("exec-1");
+  });
+
   test("competitors が 5 件（境界 OK）は通る", async () => {
     const service = buildService();
 

--- a/apps/api/src/services/executions.test.ts
+++ b/apps/api/src/services/executions.test.ts
@@ -222,4 +222,31 @@ describe("createExecutionsService.createExecution", () => {
       }),
     ).rejects.toThrow("DB connection failed");
   });
+
+  test("Template.definition.agents が空配列なら repo 到達前に Error を throw する", async () => {
+    const emptyAgentsTemplate = {
+      ...fixtureTemplate,
+      definition: { ...fixtureTemplate.definition, agents: [] },
+    };
+    let repoCalled = false;
+    const service = buildService({
+      getTemplateById: async () => emptyAgentsTemplate,
+      createExecution: async () => {
+        repoCalled = true;
+        return {
+          id: "exec-1",
+          status: "pending",
+          createdAt: "2026-05-04T00:00:00.000Z",
+        };
+      },
+    });
+
+    await expect(
+      service.createExecution({
+        templateId: fixtureTemplate.id,
+        parameters: validParameters,
+      }),
+    ).rejects.toThrow(/no agents/);
+    expect(repoCalled).toBe(false);
+  });
 });

--- a/apps/api/src/services/executions.test.ts
+++ b/apps/api/src/services/executions.test.ts
@@ -1,3 +1,6 @@
+// このファイルは app.ts を経由しないため Zod の日本語ロケール（lib/zod-config.ts）が
+// ロードされない。アサートは field キーまでに留め、reason 文言は app.test.ts 側で
+// 確認する責務分担とする。
 import { describe, expect, test } from "bun:test";
 import type { CompetitorAnalysisParameters } from "@agent-team-studio/shared";
 import { fixtureTemplate } from "../_test-fixtures.ts";
@@ -107,6 +110,17 @@ describe("createExecutionsService.createExecution", () => {
     );
   });
 
+  test("competitors が 1 件（境界 OK）は通る", async () => {
+    const service = buildService();
+
+    const res = await service.createExecution({
+      templateId: fixtureTemplate.id,
+      parameters: { competitors: ["Acme"] },
+    });
+
+    expect(res.id).toBe("exec-1");
+  });
+
   // MVP では重複チェックなし。将来 .refine(unique) を追加するなら破壊的変更となる前提を固定する。
   test("competitors の重複は許容される", async () => {
     const service = buildService();
@@ -179,7 +193,7 @@ describe("createExecutionsService.createExecution", () => {
     ).toBe(true);
   });
 
-  test("スペースのみの competitor は trim 後 min(1) で ValidationError", async () => {
+  test("スペースのみの competitor は ValidationError", async () => {
     const service = buildService();
 
     const err = await service

--- a/apps/api/src/services/executions.test.ts
+++ b/apps/api/src/services/executions.test.ts
@@ -69,6 +69,9 @@ describe("createExecutionsService.createExecution", () => {
     ).rejects.toBeInstanceOf(NotFoundError);
   });
 
+  // Zod の path は配列全体エラーで `["competitors"]`、要素エラーで `["competitors", N]` と
+  // 構造が異なる。前者は `=== "competitors"`、後者は `startsWith("competitors")` で検証する。
+
   test("competitors が空配列なら ValidationError", async () => {
     const service = buildService();
 
@@ -76,6 +79,23 @@ describe("createExecutionsService.createExecution", () => {
       .createExecution({
         templateId: fixtureTemplate.id,
         parameters: { competitors: [] },
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ValidationError);
+    const validation = err as ValidationError;
+    expect(validation.details.some((d) => d.field === "competitors")).toBe(
+      true,
+    );
+  });
+
+  test("parameters が {} で competitors キー欠落なら ValidationError", async () => {
+    const service = buildService();
+
+    const err = await service
+      .createExecution({
+        templateId: fixtureTemplate.id,
+        parameters: {} as never,
       })
       .catch((e: unknown) => e);
 

--- a/apps/api/src/services/executions.test.ts
+++ b/apps/api/src/services/executions.test.ts
@@ -166,6 +166,23 @@ describe("createExecutionsService.createExecution", () => {
     ).toBe(true);
   });
 
+  test("スペースのみの competitor は trim 後 min(1) で ValidationError", async () => {
+    const service = buildService();
+
+    const err = await service
+      .createExecution({
+        templateId: fixtureTemplate.id,
+        parameters: { competitors: ["   "] },
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ValidationError);
+    const validation = err as ValidationError;
+    expect(
+      validation.details.some((d) => d.field.startsWith("competitors")),
+    ).toBe(true);
+  });
+
   test("空文字の competitor を含むと ValidationError", async () => {
     const service = buildService();
 

--- a/apps/api/src/services/executions.test.ts
+++ b/apps/api/src/services/executions.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import type { CompetitorAnalysisParameters } from "@agent-team-studio/shared";
+import { fixtureTemplate } from "../_test-fixtures.ts";
+import { NotFoundError, ValidationError } from "../lib/errors.ts";
+import {
+  createExecutionsService,
+  type ExecutionsServiceDeps,
+} from "./executions.ts";
+
+const validParameters: CompetitorAnalysisParameters = {
+  competitors: ["Acme", "Globex"],
+  reference: "メモ",
+};
+
+const buildService = (overrides: Partial<ExecutionsServiceDeps> = {}) =>
+  createExecutionsService({
+    getTemplateById: async () => fixtureTemplate,
+    createExecution: async () => ({
+      id: "exec-1",
+      status: "pending",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    }),
+    ...overrides,
+  });
+
+describe("createExecutionsService.createExecution", () => {
+  test("Template から agents を抽出して repo に渡す", async () => {
+    let captured:
+      | Parameters<ExecutionsServiceDeps["createExecution"]>[0]
+      | undefined;
+    const service = buildService({
+      createExecution: async (input) => {
+        captured = input;
+        return {
+          id: "exec-1",
+          status: "pending",
+          createdAt: "2026-05-04T00:00:00.000Z",
+        };
+      },
+    });
+
+    const res = await service.createExecution({
+      templateId: fixtureTemplate.id,
+      parameters: validParameters,
+    });
+
+    expect(res).toEqual({
+      id: "exec-1",
+      status: "pending",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+    expect(captured?.templateId).toBe(fixtureTemplate.id);
+    expect(captured?.parameters).toEqual(validParameters);
+    // fixture は investigation 1 + integration 1 の 2 件。
+    expect(captured?.agents).toEqual([
+      { agentId: "investigator-strategy", role: "investigation" },
+      { agentId: "integrator", role: "integration" },
+    ]);
+  });
+
+  test("Template が存在しない場合は NotFoundError", async () => {
+    const service = buildService({ getTemplateById: async () => null });
+
+    await expect(
+      service.createExecution({
+        templateId: "tpl-missing",
+        parameters: validParameters,
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test("competitors が空配列なら ValidationError", async () => {
+    const service = buildService();
+
+    const err = await service
+      .createExecution({
+        templateId: fixtureTemplate.id,
+        parameters: { competitors: [] },
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ValidationError);
+    const validation = err as ValidationError;
+    expect(validation.details.some((d) => d.field === "competitors")).toBe(
+      true,
+    );
+  });
+
+  test("competitors が 5 件（境界 OK）は通る", async () => {
+    const service = buildService();
+
+    const res = await service.createExecution({
+      templateId: fixtureTemplate.id,
+      parameters: {
+        competitors: ["a", "b", "c", "d", "e"],
+      },
+    });
+
+    expect(res.id).toBe("exec-1");
+  });
+
+  test("competitors が 6 件（境界 NG）なら competitors フィールドの ValidationError", async () => {
+    const service = buildService();
+
+    const err = await service
+      .createExecution({
+        templateId: fixtureTemplate.id,
+        parameters: {
+          competitors: ["a", "b", "c", "d", "e", "f"],
+        },
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ValidationError);
+    const validation = err as ValidationError;
+    expect(validation.details.some((d) => d.field === "competitors")).toBe(
+      true,
+    );
+  });
+
+  test("competitors の各要素が 100 文字（境界 OK）は通る", async () => {
+    const service = buildService();
+
+    const res = await service.createExecution({
+      templateId: fixtureTemplate.id,
+      parameters: { competitors: ["a".repeat(100)] },
+    });
+
+    expect(res.id).toBe("exec-1");
+  });
+
+  test("空文字の competitor を含むと ValidationError", async () => {
+    const service = buildService();
+
+    const err = await service
+      .createExecution({
+        templateId: fixtureTemplate.id,
+        parameters: { competitors: ["Acme", ""] },
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ValidationError);
+    const validation = err as ValidationError;
+    expect(
+      validation.details.some((d) => d.field.startsWith("competitors")),
+    ).toBe(true);
+  });
+
+  test("reference が 10000 文字（境界 OK）は通る", async () => {
+    const service = buildService();
+
+    const res = await service.createExecution({
+      templateId: fixtureTemplate.id,
+      parameters: {
+        competitors: ["Acme"],
+        reference: "x".repeat(10000),
+      },
+    });
+
+    expect(res.id).toBe("exec-1");
+  });
+
+  test("reference が 10001 文字（境界 NG）なら ValidationError", async () => {
+    const service = buildService();
+
+    const err = await service
+      .createExecution({
+        templateId: fixtureTemplate.id,
+        parameters: {
+          competitors: ["Acme"],
+          reference: "x".repeat(10001),
+        },
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ValidationError);
+    const validation = err as ValidationError;
+    expect(validation.details.some((d) => d.field === "reference")).toBe(true);
+  });
+
+  test("バリデーションが先で Template 不在より優先する", async () => {
+    const service = buildService({ getTemplateById: async () => null });
+
+    const err = await service
+      .createExecution({
+        templateId: "tpl-missing",
+        parameters: { competitors: [] },
+      })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ValidationError);
+  });
+
+  test("Repo の例外は透過させる", async () => {
+    const service = buildService({
+      createExecution: async () => {
+        throw new Error("DB connection failed");
+      },
+    });
+
+    await expect(
+      service.createExecution({
+        templateId: fixtureTemplate.id,
+        parameters: validParameters,
+      }),
+    ).rejects.toThrow("DB connection failed");
+  });
+});

--- a/apps/api/src/services/executions.test.ts
+++ b/apps/api/src/services/executions.test.ts
@@ -95,6 +95,7 @@ describe("createExecutionsService.createExecution", () => {
     const err = await service
       .createExecution({
         templateId: fixtureTemplate.id,
+        // 型レイヤを強引に通して Zod に不正構造を渡し、ランタイム検証経路を確認する。
         parameters: {} as never,
       })
       .catch((e: unknown) => e);

--- a/apps/api/src/services/executions.ts
+++ b/apps/api/src/services/executions.ts
@@ -18,7 +18,9 @@ import { z } from "zod";
 import { NotFoundError, ValidationError } from "../lib/errors.ts";
 
 const competitorAnalysisParametersSchema = z.object({
-  competitors: z.array(z.string().min(1).max(100)).min(1).max(5),
+  // trim() してから min(1) で「スペースのみ」を弾く（UI 側で trim 済みでも
+  // API 直叩き経路を防御する）。
+  competitors: z.array(z.string().trim().min(1).max(100)).min(1).max(5),
   reference: z.string().max(10000).optional(),
 });
 

--- a/apps/api/src/services/executions.ts
+++ b/apps/api/src/services/executions.ts
@@ -1,16 +1,11 @@
 /**
  * Execution 作成 Service。
  *
- * 責務:
- * - parameters の Zod バリデーション（competitor-analysis.md §入力パラメータ JSON Schema 準拠）
- * - Template 取得（不在は `NotFoundError`）
- * - Template.definition.agents から `{ agentId, role }` を抽出して repo に渡す
+ * バリデーションは Template 取得より先に実行する。入力エラーは Template 存在有無に
+ * 依存せず判定可能で、不要な DB アクセスを避けるため。
  *
- * バリデーションは Template 取得より先に実行する（入力エラーは
- * Template の存在に依存しない判定のため）。
- *
- * MVP では parameters の型はテンプレート横断ではなく `CompetitorAnalysisParameters`
- * 1 種に固定する（domain-types.ts のコメント / ADR-0005）。
+ * MVP では parameters の型を `CompetitorAnalysisParameters` 固定とする（テンプレ横断の
+ * 抽象化は v2 で導入予定）。
  */
 
 import type { CreateExecutionInput } from "@agent-team-studio/db";

--- a/apps/api/src/services/executions.ts
+++ b/apps/api/src/services/executions.ts
@@ -16,8 +16,6 @@ import type {
 } from "@agent-team-studio/shared";
 import { z } from "zod";
 import { NotFoundError, ValidationError } from "../lib/errors.ts";
-// Zod のデフォルトメッセージを日本語にするための副作用 import。
-import "../lib/zod-config.ts";
 
 const competitorAnalysisParametersSchema = z.object({
   // trim() してから min(1) で「スペースのみ」を弾く（UI 側で trim 済みでも

--- a/apps/api/src/services/executions.ts
+++ b/apps/api/src/services/executions.ts
@@ -63,6 +63,11 @@ export function createExecutionsService(
         agentId: a.agent_id,
         role: a.role,
       }));
+      // Drizzle の `tx.insert(...).values([])` は TypeError を投げるため、
+      // agents 空のテンプレートは repo 到達前に明示的に弾く（500 経路へ）。
+      if (agents.length === 0) {
+        throw new Error(`template has no agents: ${template.id}`);
+      }
 
       return deps.createExecution({
         templateId: template.id,

--- a/apps/api/src/services/executions.ts
+++ b/apps/api/src/services/executions.ts
@@ -16,6 +16,8 @@ import type {
 } from "@agent-team-studio/shared";
 import { z } from "zod";
 import { NotFoundError, ValidationError } from "../lib/errors.ts";
+// Zod のデフォルトメッセージを日本語にするための副作用 import。
+import "../lib/zod-config.ts";
 
 const competitorAnalysisParametersSchema = z.object({
   // trim() してから min(1) で「スペースのみ」を弾く（UI 側で trim 済みでも

--- a/apps/api/src/services/executions.ts
+++ b/apps/api/src/services/executions.ts
@@ -1,0 +1,79 @@
+/**
+ * Execution 作成 Service。
+ *
+ * 責務:
+ * - parameters の Zod バリデーション（competitor-analysis.md §入力パラメータ JSON Schema 準拠）
+ * - Template 取得（不在は `NotFoundError`）
+ * - Template.definition.agents から `{ agentId, role }` を抽出して repo に渡す
+ *
+ * バリデーションは Template 取得より先に実行する（入力エラーは
+ * Template の存在に依存しない判定のため）。
+ *
+ * MVP では parameters の型はテンプレート横断ではなく `CompetitorAnalysisParameters`
+ * 1 種に固定する（domain-types.ts のコメント / ADR-0005）。
+ */
+
+import type { CreateExecutionInput } from "@agent-team-studio/db";
+import type {
+  CreateExecutionRequest,
+  CreateExecutionResponse,
+  Template,
+} from "@agent-team-studio/shared";
+import { z } from "zod";
+import { NotFoundError, ValidationError } from "../lib/errors.ts";
+
+const competitorAnalysisParametersSchema = z.object({
+  competitors: z.array(z.string().min(1).max(100)).min(1).max(5),
+  reference: z.string().max(10000).optional(),
+});
+
+export type ExecutionsService = {
+  createExecution: (
+    request: CreateExecutionRequest,
+  ) => Promise<CreateExecutionResponse>;
+};
+
+export type ExecutionsServiceDeps = {
+  getTemplateById: (id: string) => Promise<Template | null>;
+  createExecution: (
+    input: CreateExecutionInput,
+  ) => Promise<CreateExecutionResponse>;
+};
+
+export function createExecutionsService(
+  deps: ExecutionsServiceDeps,
+): ExecutionsService {
+  return {
+    async createExecution(request) {
+      const parsed = competitorAnalysisParametersSchema.safeParse(
+        request.parameters,
+      );
+      if (!parsed.success) {
+        // field 名は parameters のキー基準（api-design.md §エラーレスポンス 例と整合）。
+        // 配列要素は "competitors.0" の形でドット連結する。
+        throw new ValidationError(
+          parsed.error.issues.map((issue) => ({
+            field: issue.path.map(String).join("."),
+            reason: issue.message,
+          })),
+        );
+      }
+
+      const template = await deps.getTemplateById(request.templateId);
+      if (!template) {
+        throw new NotFoundError("template", request.templateId);
+      }
+
+      const agents = template.definition.agents.map((a) => ({
+        agentId: a.agent_id,
+        role: a.role,
+      }));
+
+      return deps.createExecution({
+        templateId: template.id,
+        parameters: parsed.data,
+        agents,
+      });
+    },
+  };
+}

--- a/apps/api/src/services/executions.ts
+++ b/apps/api/src/services/executions.ts
@@ -44,8 +44,8 @@ export function createExecutionsService(
         request.parameters,
       );
       if (!parsed.success) {
-        // field 名は parameters のキー基準（api-design.md §エラーレスポンス 例と整合）。
-        // 配列要素は "competitors.0" の形でドット連結する。
+        // 配列要素のエラーは "competitors.0" の形でドット連結し、フォーム側で
+        // 要素単位に inline 表示できるようにする。
         throw new ValidationError(
           parsed.error.issues.map((issue) => ({
             field: issue.path.map(String).join("."),

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import { Input as InputPrimitive } from "@base-ui/react/input";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    // biome-ignore lint/a11y/noLabelWithoutControl: shadcn primitive — htmlFor/children are supplied by callers
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -70,6 +70,7 @@ export function TemplateNewPage() {
   const competitorsErrorId = useId();
   const competitorItemErrorIdPrefix = useId();
   const referenceFieldId = useId();
+  const referenceHelpId = useId();
   const referenceErrorId = useId();
 
   useEffect(() => {
@@ -312,7 +313,7 @@ export function TemplateNewPage() {
 
             <div className="space-y-2">
               <Label htmlFor={referenceFieldId}>参考情報（任意）</Label>
-              <p className="text-xs text-muted-foreground">
+              <p id={referenceHelpId} className="text-xs text-muted-foreground">
                 ユーザーが手で貼り付けたテキストのみを LLM に渡す。Web
                 取得は行わない（〜10000 文字）
               </p>
@@ -325,7 +326,9 @@ export function TemplateNewPage() {
                 maxLength={10000}
                 aria-invalid={fieldErrors.reference ? true : undefined}
                 aria-describedby={
-                  fieldErrors.reference ? referenceErrorId : undefined
+                  fieldErrors.reference
+                    ? `${referenceHelpId} ${referenceErrorId}`
+                    : referenceHelpId
                 }
               />
               {fieldErrors.reference && (
@@ -335,6 +338,8 @@ export function TemplateNewPage() {
               )}
             </div>
 
+            {/* submitting → submit-error の遷移で Alert は一度アンマウント → 再挿入される。
+                同一メッセージで再送信した場合も role="alert" が再アナウンスされるのはこの挙動に依存する。 */}
             {submitState.kind === "submit-error" && (
               <Alert variant="destructive">
                 <AlertTitle>実行を開始できませんでした</AlertTitle>

--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -65,6 +65,7 @@ export function TemplateNewPage() {
   const headingRef = useRef<HTMLHeadingElement>(null);
   const competitorRefs = useRef<(HTMLInputElement | null)[]>([]);
   const referenceRef = useRef<HTMLTextAreaElement>(null);
+  const submitButtonRef = useRef<HTMLButtonElement>(null);
   const competitorsLabelId = useId();
   const competitorsHelpId = useId();
   const competitorsErrorId = useId();
@@ -117,6 +118,15 @@ export function TemplateNewPage() {
     }
     if (errors.reference) {
       referenceRef.current?.focus();
+    }
+  }, [submitState]);
+
+  // submit-error 遷移時は submit ボタンへフォーカスを戻す。submitting 中は disabled で
+  // フォーカスが body へ落ちており、Alert は role="alert" のみで focus は奪わない方針
+  // （ui-patterns.md §7）のため、明示的にボタンへ復帰させる。
+  useEffect(() => {
+    if (submitState.kind === "submit-error") {
+      submitButtonRef.current?.focus();
     }
   }, [submitState]);
 
@@ -364,7 +374,11 @@ export function TemplateNewPage() {
             )}
 
             <div className="flex gap-2">
-              <Button type="submit" disabled={submitDisabled}>
+              <Button
+                ref={submitButtonRef}
+                type="submit"
+                disabled={submitDisabled}
+              >
                 {submitState.kind === "submitting" ? (
                   <>
                     <Loader2 className="animate-spin" aria-hidden="true" />

--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -1,14 +1,6 @@
 /**
- * 入力フォーム画面（[US-2](docs/product/user-stories.md#us-2-調査パラメータを入力して実行する)）。
- *
- * 入力スキーマは MVP の競合調査テンプレート固定（[ADR-0005](docs/adr/0005-mvp-scope.md),
- * [competitor-analysis.md](docs/design/templates/competitor-analysis.md)）。複数テンプレ対応は v2。
- *
- * バリデーションエラーは API の `details[].field` をそのままフォーム要素直下に
- * inline 表示する（[ui-patterns.md §3.3 error](docs/design/ui-patterns.md)）。
- *
- * Router 固有 API（loader / action）には寄せず、`fetch` は `useEffect` / submit ハンドラ内に
- * 閉じる（[ADR-0025](docs/adr/0025-spa-routing-library.md) Decision）。
+ * 競合調査テンプレート専用の入力フォーム。MVP では `parameters` 構造をテンプレ横断で
+ * 抽象化せず、`CompetitorAnalysisParameters` に固定する（v2 で動的化予定）。
  */
 
 import type {
@@ -19,6 +11,7 @@ import type {
   CreateExecutionResponse,
   GetTemplateResponse,
 } from "@agent-team-studio/shared";
+import { Loader2 } from "lucide-react";
 import {
   type FormEvent,
   useCallback,
@@ -65,8 +58,13 @@ export function TemplateNewPage() {
   const [competitors, setCompetitors] = useState<string[]>([""]);
   const [reference, setReference] = useState("");
   const [submitState, setSubmitState] = useState<SubmitState>({ kind: "idle" });
+  // 再試行ボタンで useEffect を再実行するためのカウンタ。fetch の中断・state 衝突を
+  // useEffect の cleanup で一元管理する（独立した abort パスを持たせない）。
+  const [reloadCounter, setReloadCounter] = useState(0);
 
   const headingRef = useRef<HTMLHeadingElement>(null);
+  const competitorRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const referenceRef = useRef<HTMLTextAreaElement>(null);
   const competitorsLabelId = useId();
   const competitorsHelpId = useId();
   const competitorsErrorId = useId();
@@ -78,6 +76,8 @@ export function TemplateNewPage() {
     headingRef.current?.focus();
   }, []);
 
+  // reloadCounter は再試行ボタンの再実行トリガ。effect 内で参照しないが意図的に依存として残す。
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reloadCounter is intentional retry trigger
   useEffect(() => {
     if (!templateId) {
       setLoadState({ kind: "load-error" });
@@ -99,7 +99,25 @@ export function TemplateNewPage() {
     return () => {
       aborted = true;
     };
-  }, [templateId]);
+  }, [templateId, reloadCounter]);
+
+  useEffect(() => {
+    if (submitState.kind !== "validation-error") return;
+    const errors = submitState.errors;
+    if (errors.competitors) {
+      competitorRefs.current[0]?.focus();
+      return;
+    }
+    const itemIndices = Object.keys(errors.competitorItems).map(Number);
+    if (itemIndices.length > 0) {
+      const first = Math.min(...itemIndices);
+      competitorRefs.current[first]?.focus();
+      return;
+    }
+    if (errors.reference) {
+      referenceRef.current?.focus();
+    }
+  }, [submitState]);
 
   const filledCount = competitors.filter((c) => c.trim().length > 0).length;
   const submitDisabled =
@@ -167,11 +185,7 @@ export function TemplateNewPage() {
 
   return (
     <section>
-      <h1
-        ref={headingRef}
-        tabIndex={-1}
-        className="mb-2 text-xl font-semibold focus:outline-none"
-      >
+      <h1 ref={headingRef} tabIndex={-1} className="mb-2 text-xl font-semibold">
         入力フォーム
       </h1>
 
@@ -182,6 +196,15 @@ export function TemplateNewPage() {
           <AlertTitle>テンプレートを取得できませんでした</AlertTitle>
           <AlertDescription>
             <p>時間をおいて再度お試しください。</p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-2"
+              onClick={() => setReloadCounter((c) => c + 1)}
+            >
+              再試行
+            </Button>
           </AlertDescription>
         </Alert>
       )}
@@ -226,9 +249,13 @@ export function TemplateNewPage() {
                     <li key={index} className="flex items-start gap-2">
                       <div className="flex-1">
                         <Input
+                          ref={(el) => {
+                            competitorRefs.current[index] = el;
+                          }}
                           aria-labelledby={competitorsLabelId}
                           aria-describedby={describedBy}
                           aria-invalid={itemError ? true : undefined}
+                          aria-required="true"
                           value={value}
                           onChange={(e) => {
                             const next = [...competitors];
@@ -290,6 +317,7 @@ export function TemplateNewPage() {
                 取得は行わない（〜10000 文字）
               </p>
               <Textarea
+                ref={referenceRef}
                 id={referenceFieldId}
                 value={reference}
                 onChange={(e) => setReference(e.target.value)}
@@ -316,7 +344,14 @@ export function TemplateNewPage() {
 
             <div className="flex gap-2">
               <Button type="submit" disabled={submitDisabled}>
-                {submitState.kind === "submitting" ? "実行中…" : "実行する"}
+                {submitState.kind === "submitting" ? (
+                  <>
+                    <Loader2 className="animate-spin" aria-hidden="true" />
+                    実行中…
+                  </>
+                ) : (
+                  "実行する"
+                )}
               </Button>
             </div>
           </form>

--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -66,7 +66,6 @@ export function TemplateNewPage() {
   const competitorRefs = useRef<(HTMLInputElement | null)[]>([]);
   const referenceRef = useRef<HTMLTextAreaElement>(null);
   const submitButtonRef = useRef<HTMLButtonElement>(null);
-  const competitorsLabelId = useId();
   const competitorsHelpId = useId();
   const competitorsErrorId = useId();
   const competitorItemErrorIdPrefix = useId();
@@ -244,10 +243,7 @@ export function TemplateNewPage() {
 
           <form onSubmit={handleSubmit} noValidate className="space-y-6">
             <fieldset className="space-y-2">
-              <legend
-                id={competitorsLabelId}
-                className="text-sm font-medium leading-none"
-              >
+              <legend className="text-sm font-medium leading-none">
                 競合企業名 <span aria-hidden="true">*</span>
               </legend>
               <p
@@ -279,7 +275,7 @@ export function TemplateNewPage() {
                           ref={(el) => {
                             competitorRefs.current[index] = el;
                           }}
-                          aria-labelledby={competitorsLabelId}
+                          aria-label={`競合企業 ${index + 1}`}
                           aria-describedby={describedBy}
                           aria-invalid={itemError ? true : undefined}
                           aria-required="true"

--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -1,20 +1,169 @@
 /**
- * 入力フォーム画面のプレースホルダ（[US-2](docs/product/user-stories.md#us-2-調査パラメータを入力して実行する) で実装）。
+ * 入力フォーム画面（[US-2](docs/product/user-stories.md#us-2-調査パラメータを入力して実行する)）。
  *
- * US-1 では到達確認のみが目的のため、`templateId` を表示する空ページに留める。
- * 画面の実装は次 Issue で `features/templates/TemplateNewPage.tsx` を上書きする想定。
+ * 入力スキーマは MVP の競合調査テンプレート固定（[ADR-0005](docs/adr/0005-mvp-scope.md),
+ * [competitor-analysis.md](docs/design/templates/competitor-analysis.md)）。複数テンプレ対応は v2。
+ *
+ * バリデーションエラーは API の `details[].field` をそのままフォーム要素直下に
+ * inline 表示する（[ui-patterns.md §3.3 error](docs/design/ui-patterns.md)）。
+ *
+ * Router 固有 API（loader / action）には寄せず、`fetch` は `useEffect` / submit ハンドラ内に
+ * 閉じる（[ADR-0025](docs/adr/0025-spa-routing-library.md) Decision）。
  */
 
-import { useEffect, useRef } from "react";
-import { useParams } from "react-router";
+import type {
+  ApiError,
+  ApiValidationError,
+  CompetitorAnalysisParameters,
+  CreateExecutionRequest,
+  CreateExecutionResponse,
+  GetTemplateResponse,
+} from "@agent-team-studio/shared";
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { useNavigate, useParams } from "react-router";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+
+const MAX_COMPETITORS = 5;
+const MIN_COMPETITORS = 1;
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "ready"; template: GetTemplateResponse }
+  | { kind: "load-error" };
+
+type FieldErrors = {
+  competitors?: string;
+  competitorItems: Record<number, string>;
+  reference?: string;
+};
+
+type SubmitState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "submit-error"; message: string }
+  | { kind: "validation-error"; errors: FieldErrors };
+
+const emptyFieldErrors: FieldErrors = { competitorItems: {} };
 
 export function TemplateNewPage() {
   const { templateId } = useParams();
-  // ui-patterns.md §7 / WCAG 2.1 SC 2.4.3: 画面遷移直後は <h1> に focus。
+  const navigate = useNavigate();
+
+  const [loadState, setLoadState] = useState<LoadState>({ kind: "loading" });
+  const [competitors, setCompetitors] = useState<string[]>([""]);
+  const [reference, setReference] = useState("");
+  const [submitState, setSubmitState] = useState<SubmitState>({ kind: "idle" });
+
   const headingRef = useRef<HTMLHeadingElement>(null);
+  const competitorsLabelId = useId();
+  const competitorsHelpId = useId();
+  const competitorsErrorId = useId();
+  const competitorItemErrorIdPrefix = useId();
+  const referenceFieldId = useId();
+  const referenceErrorId = useId();
+
   useEffect(() => {
     headingRef.current?.focus();
   }, []);
+
+  useEffect(() => {
+    if (!templateId) {
+      setLoadState({ kind: "load-error" });
+      return;
+    }
+    let aborted = false;
+    setLoadState({ kind: "loading" });
+    fetch(`/api/templates/${templateId}`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`status=${res.status}`);
+        return (await res.json()) as GetTemplateResponse;
+      })
+      .then((template) => {
+        if (!aborted) setLoadState({ kind: "ready", template });
+      })
+      .catch(() => {
+        if (!aborted) setLoadState({ kind: "load-error" });
+      });
+    return () => {
+      aborted = true;
+    };
+  }, [templateId]);
+
+  const filledCount = competitors.filter((c) => c.trim().length > 0).length;
+  const submitDisabled =
+    submitState.kind === "submitting" ||
+    filledCount < MIN_COMPETITORS ||
+    loadState.kind !== "ready";
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!templateId) return;
+      // 空行はサーバ送信前に除外する。残りで MIN を満たさなければ disabled で押下不可のため到達しない。
+      const cleanedCompetitors = competitors
+        .map((c) => c.trim())
+        .filter((c) => c.length > 0);
+      const trimmedReference = reference.trim();
+      const parameters: CompetitorAnalysisParameters = {
+        competitors: cleanedCompetitors,
+        ...(trimmedReference.length > 0 ? { reference: trimmedReference } : {}),
+      };
+      const body: CreateExecutionRequest = {
+        templateId,
+        parameters,
+      };
+
+      setSubmitState({ kind: "submitting" });
+      try {
+        const res = await fetch("/api/executions", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (res.status === 202) {
+          const created = (await res.json()) as CreateExecutionResponse;
+          navigate(`/executions/${created.id}`);
+          return;
+        }
+        const err = (await res.json().catch(() => null)) as ApiError | null;
+        if (err?.errorCode === "validation_error") {
+          setSubmitState({
+            kind: "validation-error",
+            errors: mapValidationErrors(err),
+          });
+          return;
+        }
+        setSubmitState({
+          kind: "submit-error",
+          message:
+            err?.message ?? "実行を開始できませんでした。再度お試しください",
+        });
+      } catch {
+        setSubmitState({
+          kind: "submit-error",
+          message: "実行を開始できませんでした。再度お試しください",
+        });
+      }
+    },
+    [competitors, navigate, reference, templateId],
+  );
+
+  const fieldErrors =
+    submitState.kind === "validation-error"
+      ? submitState.errors
+      : emptyFieldErrors;
 
   return (
     <section>
@@ -25,9 +174,187 @@ export function TemplateNewPage() {
       >
         入力フォーム
       </h1>
-      <p className="text-sm text-muted-foreground">
-        US-2 で実装予定です（templateId: {templateId ?? "(none)"}）。
-      </p>
+
+      {loadState.kind === "loading" && <FormSkeleton />}
+
+      {loadState.kind === "load-error" && (
+        <Alert variant="destructive">
+          <AlertTitle>テンプレートを取得できませんでした</AlertTitle>
+          <AlertDescription>
+            <p>時間をおいて再度お試しください。</p>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {loadState.kind === "ready" && (
+        <>
+          <p className="mb-6 text-sm text-muted-foreground">
+            {loadState.template.name} ・ {loadState.template.description}
+          </p>
+
+          <form onSubmit={handleSubmit} noValidate className="space-y-6">
+            <fieldset className="space-y-2">
+              <legend
+                id={competitorsLabelId}
+                className="text-sm font-medium leading-none"
+              >
+                競合企業名 <span aria-hidden="true">*</span>
+              </legend>
+              <p
+                id={competitorsHelpId}
+                className="text-xs text-muted-foreground"
+              >
+                {MIN_COMPETITORS}〜{MAX_COMPETITORS} 件、各 1〜100 文字
+              </p>
+              <ul className="space-y-2">
+                {competitors.map((value, index) => {
+                  const itemError = fieldErrors.competitorItems[index];
+                  const itemErrorId = `${competitorItemErrorIdPrefix}-${index}`;
+                  // 各 input には説明 (help) と「グループ全体エラー / 自身のエラー」を結合する。
+                  // 空 id を含めないように filter で空白を除去する。
+                  const describedBy =
+                    [
+                      competitorsHelpId,
+                      fieldErrors.competitors ? competitorsErrorId : "",
+                      itemError ? itemErrorId : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ") || undefined;
+                  return (
+                    // 並び替えなし・index と表示順を 1:1 で同期する素朴な実装。
+                    // biome-ignore lint/suspicious/noArrayIndexKey: index と表示位置が同期し並び替えしないため安定
+                    <li key={index} className="flex items-start gap-2">
+                      <div className="flex-1">
+                        <Input
+                          aria-labelledby={competitorsLabelId}
+                          aria-describedby={describedBy}
+                          aria-invalid={itemError ? true : undefined}
+                          value={value}
+                          onChange={(e) => {
+                            const next = [...competitors];
+                            next[index] = e.target.value;
+                            setCompetitors(next);
+                          }}
+                          placeholder={`競合企業 ${index + 1}`}
+                          maxLength={100}
+                        />
+                        {itemError && (
+                          <p
+                            id={itemErrorId}
+                            className="mt-1 text-xs text-destructive"
+                          >
+                            {itemError}
+                          </p>
+                        )}
+                      </div>
+                      {competitors.length > 1 && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setCompetitors(
+                              competitors.filter((_, i) => i !== index),
+                            );
+                          }}
+                          aria-label={`競合企業 ${index + 1} を削除`}
+                        >
+                          削除
+                        </Button>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+              {competitors.length < MAX_COMPETITORS && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCompetitors([...competitors, ""])}
+                >
+                  競合企業を追加
+                </Button>
+              )}
+              {fieldErrors.competitors && (
+                <p id={competitorsErrorId} className="text-xs text-destructive">
+                  {fieldErrors.competitors}
+                </p>
+              )}
+            </fieldset>
+
+            <div className="space-y-2">
+              <Label htmlFor={referenceFieldId}>参考情報（任意）</Label>
+              <p className="text-xs text-muted-foreground">
+                ユーザーが手で貼り付けたテキストのみを LLM に渡す。Web
+                取得は行わない（〜10000 文字）
+              </p>
+              <Textarea
+                id={referenceFieldId}
+                value={reference}
+                onChange={(e) => setReference(e.target.value)}
+                rows={6}
+                maxLength={10000}
+                aria-invalid={fieldErrors.reference ? true : undefined}
+                aria-describedby={
+                  fieldErrors.reference ? referenceErrorId : undefined
+                }
+              />
+              {fieldErrors.reference && (
+                <p id={referenceErrorId} className="text-xs text-destructive">
+                  {fieldErrors.reference}
+                </p>
+              )}
+            </div>
+
+            {submitState.kind === "submit-error" && (
+              <Alert variant="destructive">
+                <AlertTitle>実行を開始できませんでした</AlertTitle>
+                <AlertDescription>{submitState.message}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="flex gap-2">
+              <Button type="submit" disabled={submitDisabled}>
+                {submitState.kind === "submitting" ? "実行中…" : "実行する"}
+              </Button>
+            </div>
+          </form>
+        </>
+      )}
     </section>
+  );
+}
+
+function mapValidationErrors(err: ApiValidationError): FieldErrors {
+  const result: FieldErrors = { competitorItems: {} };
+  for (const detail of err.details) {
+    if (detail.field === "competitors") {
+      result.competitors = detail.reason;
+      continue;
+    }
+    const competitorMatch = /^competitors\.(\d+)$/.exec(detail.field);
+    if (competitorMatch) {
+      const index = Number.parseInt(competitorMatch[1] ?? "", 10);
+      if (Number.isFinite(index)) {
+        result.competitorItems[index] = detail.reason;
+      }
+      continue;
+    }
+    if (detail.field === "reference") {
+      result.reference = detail.reason;
+    }
+  }
+  return result;
+}
+
+function FormSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-9 w-full" />
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-9 w-32" />
+    </div>
   );
 }

--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -131,9 +131,17 @@ export function TemplateNewPage() {
       event.preventDefault();
       if (!templateId) return;
       // 空行はサーバ送信前に除外する。残りで MIN を満たさなければ disabled で押下不可のため到達しない。
-      const cleanedCompetitors = competitors
-        .map((c) => c.trim())
-        .filter((c) => c.length > 0);
+      // 同時に「送信後 index → UI 配列 index」の対応マップも作る。サーバの validation_error
+      // が `competitors.N` を返したとき、UI 表示位置（空行を含む）に正しく復元するため。
+      const cleanedCompetitors: string[] = [];
+      const cleanedToUiIndex: number[] = [];
+      competitors.forEach((c, uiIndex) => {
+        const trimmed = c.trim();
+        if (trimmed.length > 0) {
+          cleanedCompetitors.push(trimmed);
+          cleanedToUiIndex.push(uiIndex);
+        }
+      });
       const trimmedReference = reference.trim();
       const parameters: CompetitorAnalysisParameters = {
         competitors: cleanedCompetitors,
@@ -160,7 +168,7 @@ export function TemplateNewPage() {
         if (err?.errorCode === "validation_error") {
           setSubmitState({
             kind: "validation-error",
-            errors: mapValidationErrors(err),
+            errors: mapValidationErrors(err, cleanedToUiIndex),
           });
           return;
         }
@@ -366,7 +374,10 @@ export function TemplateNewPage() {
   );
 }
 
-function mapValidationErrors(err: ApiValidationError): FieldErrors {
+function mapValidationErrors(
+  err: ApiValidationError,
+  cleanedToUiIndex: number[],
+): FieldErrors {
   const result: FieldErrors = { competitorItems: {} };
   for (const detail of err.details) {
     if (detail.field === "competitors") {
@@ -375,9 +386,10 @@ function mapValidationErrors(err: ApiValidationError): FieldErrors {
     }
     const competitorMatch = /^competitors\.(\d+)$/.exec(detail.field);
     if (competitorMatch) {
-      const index = Number.parseInt(competitorMatch[1] ?? "", 10);
-      if (Number.isFinite(index)) {
-        result.competitorItems[index] = detail.reason;
+      const cleanedIndex = Number.parseInt(competitorMatch[1] ?? "", 10);
+      const uiIndex = cleanedToUiIndex[cleanedIndex];
+      if (Number.isFinite(uiIndex) && uiIndex !== undefined) {
+        result.competitorItems[uiIndex] = detail.reason;
       }
       continue;
     }

--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -166,10 +166,18 @@ export function TemplateNewPage() {
         }
         const err = (await res.json().catch(() => null)) as ApiError | null;
         if (err?.errorCode === "validation_error") {
-          setSubmitState({
-            kind: "validation-error",
-            errors: mapValidationErrors(err, cleanedToUiIndex),
-          });
+          const mapped = mapValidationErrors(err, cleanedToUiIndex);
+          // 既知フィールドが何もマップできなかった（サーバ側の制約変更等で
+          // UI が認識しないフィールド名が返ってきた）場合は無音失敗を防ぐため
+          // submit-error にフォールバックする。
+          if (!mapped) {
+            setSubmitState({
+              kind: "submit-error",
+              message: err.message ?? "入力に誤りがあります",
+            });
+            return;
+          }
+          setSubmitState({ kind: "validation-error", errors: mapped });
           return;
         }
         setSubmitState({
@@ -377,27 +385,31 @@ export function TemplateNewPage() {
 function mapValidationErrors(
   err: ApiValidationError,
   cleanedToUiIndex: number[],
-): FieldErrors {
+): FieldErrors | null {
   const result: FieldErrors = { competitorItems: {} };
+  let mappedCount = 0;
   for (const detail of err.details) {
     if (detail.field === "competitors") {
       result.competitors = detail.reason;
+      mappedCount++;
       continue;
     }
     const competitorMatch = /^competitors\.(\d+)$/.exec(detail.field);
     if (competitorMatch) {
       const cleanedIndex = Number.parseInt(competitorMatch[1] ?? "", 10);
       const uiIndex = cleanedToUiIndex[cleanedIndex];
-      if (Number.isFinite(uiIndex) && uiIndex !== undefined) {
+      if (uiIndex !== undefined) {
         result.competitorItems[uiIndex] = detail.reason;
+        mappedCount++;
       }
       continue;
     }
     if (detail.field === "reference") {
       result.reference = detail.reason;
+      mappedCount++;
     }
   }
-  return result;
+  return mappedCount > 0 ? result : null;
 }
 
 function FormSkeleton() {

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "@agent-team-studio/db": "workspace:*",
         "@agent-team-studio/shared": "workspace:*",
         "hono": "^4.12.15",
+        "zod": "^4.3.6",
       },
     },
     "apps/web": {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7,5 +7,6 @@
  */
 
 export { createDbClient, type DbClient, type DrizzleDb } from "./client.ts";
+export * from "./repositories/executions.ts";
 export * from "./repositories/templates.ts";
 export * as schema from "./schema/index.ts";

--- a/packages/db/src/repositories/executions.ts
+++ b/packages/db/src/repositories/executions.ts
@@ -1,0 +1,72 @@
+/**
+ * `executions` / `agent_executions` テーブルへの書き込み repo。
+ *
+ * `createExecution` は Execution 1 件と AgentExecution × N をトランザクションで INSERT する。
+ * agent-execution.md §4 副作用順序（Execution INSERT → AgentExecution INSERT）を守る。
+ * 途中失敗時は両方ロールバックされる。両者は同一 commit で確定するため、
+ * WS 初期スナップショット等の外部観測者は「Execution あり / AgentExecution 0 件」の
+ * 中間状態を観測しない（agent-execution.md §4 / websocket-design.md §接続ライフサイクル）。
+ *
+ * 戻り値は API レスポンス（CreateExecutionResponse）に必要な最小フィールドに限定する。
+ */
+
+import type {
+  AgentRole,
+  CompetitorAnalysisParameters,
+  ExecutionId,
+  ExecutionStatus,
+  TemplateId,
+} from "@agent-team-studio/shared";
+import type { DrizzleDb } from "../client.ts";
+import { agentExecutions, executions } from "../schema/index.ts";
+
+export type CreateExecutionInput = {
+  templateId: TemplateId;
+  parameters: CompetitorAnalysisParameters;
+  agents: { agentId: string; role: AgentRole }[];
+};
+
+export type CreateExecutionResult = {
+  id: ExecutionId;
+  status: ExecutionStatus;
+  createdAt: string;
+};
+
+export async function createExecution(
+  db: DrizzleDb,
+  input: CreateExecutionInput,
+): Promise<CreateExecutionResult> {
+  return db.transaction(async (tx) => {
+    const [execution] = await tx
+      .insert(executions)
+      .values({
+        templateId: input.templateId,
+        parameters: input.parameters,
+        status: "pending",
+      })
+      .returning({
+        id: executions.id,
+        status: executions.status,
+        createdAt: executions.createdAt,
+      });
+
+    if (!execution) {
+      throw new Error("failed to insert execution");
+    }
+
+    await tx.insert(agentExecutions).values(
+      input.agents.map((a) => ({
+        executionId: execution.id,
+        agentId: a.agentId,
+        role: a.role,
+        status: "pending" as const,
+      })),
+    );
+
+    return {
+      id: execution.id,
+      status: execution.status,
+      createdAt: execution.createdAt.toISOString(),
+    };
+  });
+}

--- a/packages/db/src/repositories/executions.ts
+++ b/packages/db/src/repositories/executions.ts
@@ -1,20 +1,13 @@
 /**
- * `executions` / `agent_executions` テーブルへの書き込み repo。
- *
- * `createExecution` は Execution 1 件と AgentExecution × N をトランザクションで INSERT する。
- * agent-execution.md §4 副作用順序（Execution INSERT → AgentExecution INSERT）を守る。
- * 途中失敗時は両方ロールバックされる。両者は同一 commit で確定するため、
- * WS 初期スナップショット等の外部観測者は「Execution あり / AgentExecution 0 件」の
- * 中間状態を観測しない（agent-execution.md §4 / websocket-design.md §接続ライフサイクル）。
- *
- * 戻り値は API レスポンス（CreateExecutionResponse）に必要な最小フィールドに限定する。
+ * Execution 1 件と AgentExecution × N を同一トランザクションで INSERT する。
+ * 両者を同一 commit で確定させることで、外部観測者が「Execution あり / AgentExecution 0 件」
+ * の中間状態を見ないことを保証する。
  */
 
 import type {
   AgentRole,
   CompetitorAnalysisParameters,
-  ExecutionId,
-  ExecutionStatus,
+  CreateExecutionResponse,
   TemplateId,
 } from "@agent-team-studio/shared";
 import type { DrizzleDb } from "../client.ts";
@@ -26,16 +19,10 @@ export type CreateExecutionInput = {
   agents: { agentId: string; role: AgentRole }[];
 };
 
-export type CreateExecutionResult = {
-  id: ExecutionId;
-  status: ExecutionStatus;
-  createdAt: string;
-};
-
 export async function createExecution(
   db: DrizzleDb,
   input: CreateExecutionInput,
-): Promise<CreateExecutionResult> {
+): Promise<CreateExecutionResponse> {
   return db.transaction(async (tx) => {
     const [execution] = await tx
       .insert(executions)

--- a/packages/db/src/repositories/executions.ts
+++ b/packages/db/src/repositories/executions.ts
@@ -13,6 +13,10 @@ import type {
 import type { DrizzleDb } from "../client.ts";
 import { agentExecutions, executions } from "../schema/index.ts";
 
+/**
+ * 呼び出し元（apps/api の service 層）で Zod による検証・正規化（trim 等）が
+ * 完了している前提で受け取る。repo 層では再検証しない。
+ */
 export type CreateExecutionInput = {
   templateId: TemplateId;
   parameters: CompetitorAnalysisParameters;


### PR DESCRIPTION
## What

US-2「調査パラメータを入力して実行する」を実装する。

- **packages/db**: `createExecution` repo を追加（Execution 1 件 + AgentExecution × N をトランザクションで INSERT、agent-execution.md §4 副作用順序を遵守）
- **apps/api**: `POST /api/executions`（202 Accepted / `ApiValidationError` 400 / `ApiNotFoundError` 404）を追加。Service 層で Zod による parameters バリデーション → Template 取得 → agents 抽出 → repo 呼び出し
- **apps/api**: `ValidationError` クラスと onError ハンドラを追加（`ApiValidationError` 形へ整形）
- **apps/web**: `TemplateNewPage` を実装。競合企業名（動的追加・1〜5 件）+ 参考情報 textarea + 必須未入力時 `disabled`。submit 後 `/executions/:id` へ遷移、サーバ側 `validation_error` を `details[].field` で inline 表示
- **apps/web**: shadcn `input` / `textarea` / `label` を追加

## Why

closes #118

US-1（#117）で選択したテンプレートに対し、`competitor-analysis.md` の `input_schema` に従ったフォームを描画し、`POST /api/executions` で実行を開始するための画面・API。実行作成後は進捗画面（US-3）へ遷移する。

## How

- **レイヤー**: route → service → repo を関数注入で貫通（ADR-0023 §4 軽量 DI）。`AppDeps.createExecution` の引数型は repo の `CreateExecutionInput` を import して二重定義を回避
- **テスト戦略**: Service 層を RED → GREEN で先行（境界値 OK 側 + NG 側 / 例外透過 / バリデーション先行）。Route は `app.request()` で 202 / 400 / 404 / 500 を統合検証。Repo は Walking Skeleton スタンスに沿って手動 + 統合確認
- **UI 動作確認**: Playwright MCP で「テンプレート選択 → 入力 → submit → 202 受領 → DB に Execution 1 + AgentExecution 5（pending）」を確認済み
- **MVP 固定**: parameters 検証は competitor-analysis 専用の Zod スキーマをハードコード。複数テンプレ対応は v2（Issue 備考と整合）
- **進捗画面の URL**: `/executions/:executionId` への navigate は実装するが、ルート定義は US-3 で追加するため現状は `*` → `/` に飲まれる挙動を許容

## スコープ外として残した課題（フォローアップ Issue 候補）

- fixture の `agent_id` を `agent-execution.md §3` 命名規約（`investigation:strategy` 等）に揃える（既存 fixture の問題）
- 入力スキーマの動的レンダリング（`input_schema` を読んでフォーム自動生成）は v2

## Checklist

- [x] テストが通ること（lint / lint:md / lint:secret / type-check / test / build すべて緑）
- [ ] ドキュメントを更新したこと（該当なし）