### PR TITLE
feat(agent-core): Agent + Engine 本体実装 #132

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,7 @@
       "Skill(review)",
       "mcp__context7",
       "mcp__playwright",
+      "Bash(bun -v)",
       "Bash(bun run:*)",
       "Bash(bun test:*)",
       "Bash(bunx shadcn:*)",

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -10,7 +10,7 @@
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "type-check": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test --env-file ../../.env"
   },
   "dependencies": {
     "@agent-team-studio/shared": "workspace:*",

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -10,7 +10,7 @@
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "type-check": "tsc --noEmit",
-    "test": "bun test --env-file ../../.env"
+    "test": "bun test"
   },
   "dependencies": {
     "@agent-team-studio/shared": "workspace:*",

--- a/packages/agent-core/src/agent.test.ts
+++ b/packages/agent-core/src/agent.test.ts
@@ -331,6 +331,14 @@ describe("runIntegrationAgent", () => {
     if (!result.success) {
       expect(result.reason).toBe("output_parse_error");
     }
+
+    const failEvent = deps.capturedEvents.find(
+      (e) => e.kind === "agent_failed",
+    );
+    expect(failEvent).toBeDefined();
+    if (failEvent?.kind === "agent_failed") {
+      expect(failEvent.reason).toBe("output_parse_error");
+    }
   });
 
   test("LLM エラー → agent_failed('llm_error')", async () => {

--- a/packages/agent-core/src/agent.test.ts
+++ b/packages/agent-core/src/agent.test.ts
@@ -348,6 +348,14 @@ describe("runIntegrationAgent", () => {
     if (!result.success) {
       expect(result.reason).toBe("llm_error");
     }
+
+    const failEvent = deps.capturedEvents.find(
+      (e) => e.kind === "agent_failed",
+    );
+    expect(failEvent).toBeDefined();
+    if (failEvent?.kind === "agent_failed") {
+      expect(failEvent.reason).toBe("llm_error");
+    }
   });
 
   test("investigation_results プレースホルダに成功した調査結果が展開される", async () => {

--- a/packages/agent-core/src/agent.test.ts
+++ b/packages/agent-core/src/agent.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentDeps,
+  AgentExecutionPatch,
+  IntegrationAgentRunInput,
+  InvestigationAgentRunInput,
+} from "./agent.ts";
+import { runIntegrationAgent, runInvestigationAgent } from "./agent.ts";
+import type { AgentEvent } from "./events.ts";
+import type { LlmInput } from "./llm-client.ts";
+
+// ---- フィクスチャ ----
+
+const baseLlm = {
+  model: "claude-sonnet-4-6",
+  temperature_by_role: { investigation: 0.3, integration: 0.2 },
+  max_tokens_by_role: { investigation: 2048, integration: 4096 },
+};
+
+const baseParams = { competitors: ["CompanyA", "CompanyB"] };
+
+const investigationDef = {
+  role: "investigation" as const,
+  agent_id: "investigation:strategy",
+  specialization: {
+    perspective_key: "strategy",
+    perspective_name_ja: "戦略",
+    perspective_description: "事業戦略",
+  },
+  system_prompt_template:
+    "あなたは専門家です。観点: {{perspective_name_ja}}。企業: {{competitors}}。{{reference_or_empty}}",
+};
+
+const integrationDef = {
+  role: "integration" as const,
+  agent_id: "integration:matrix",
+  system_prompt_template:
+    "統合エージェント。企業: {{competitors}}。調査結果: {{investigation_results}}。{{reference_or_empty}}",
+};
+
+const validInvestigationJson = JSON.stringify({
+  perspective: "strategy",
+  findings: [
+    {
+      competitor: "CompanyA",
+      points: ["点1"],
+      evidence_level: "strong",
+    },
+  ],
+});
+
+const validIntegrationOutput = {
+  matrix: [
+    {
+      perspective: "strategy",
+      cells: [
+        {
+          competitor: "CompanyA",
+          summary: "要約",
+          source_evidence_level: "strong",
+        },
+      ],
+    },
+  ],
+  overall_insights: ["所見1"],
+  missing: [],
+};
+
+const validIntegrationRaw = `## Markdown レポート\n\nマトリクス\n\n${JSON.stringify(validIntegrationOutput)}`;
+
+// ---- ヘルパー ----
+
+function makeDeps(
+  streamChunks: string[],
+  overrides?: Partial<AgentDeps>,
+): AgentDeps & {
+  capturedPatches: Array<{ id: string; patch: AgentExecutionPatch }>;
+  capturedEvents: AgentEvent[];
+} {
+  const capturedPatches: Array<{ id: string; patch: AgentExecutionPatch }> = [];
+  const capturedEvents: AgentEvent[] = [];
+
+  async function* fakeStream(): AsyncIterable<string> {
+    for (const chunk of streamChunks) {
+      yield chunk;
+    }
+  }
+
+  return {
+    stream:
+      overrides?.stream ??
+      ((_input: LlmInput, _signal?: AbortSignal) => fakeStream()),
+    updateAgentExecution:
+      overrides?.updateAgentExecution ??
+      (async (id: string, patch: AgentExecutionPatch) => {
+        capturedPatches.push({ id, patch });
+      }),
+    onEvent:
+      overrides?.onEvent ??
+      ((event: AgentEvent) => {
+        capturedEvents.push(event);
+      }),
+    capturedPatches,
+    capturedEvents,
+  };
+}
+
+const baseInvestigationInput: InvestigationAgentRunInput = {
+  agentExecutionId: "ae-1",
+  agentId: "investigation:strategy",
+  definition: investigationDef,
+  parameters: baseParams,
+  llm: baseLlm,
+  signal: new AbortController().signal,
+};
+
+const baseIntegrationInput: IntegrationAgentRunInput = {
+  agentExecutionId: "ae-5",
+  agentId: "integration:matrix",
+  definition: integrationDef,
+  parameters: baseParams,
+  successfulInvestigations: [
+    {
+      agentId: "investigation:strategy",
+      output: {
+        perspective: "strategy",
+        findings: [
+          { competitor: "CompanyA", points: ["点1"], evidence_level: "strong" },
+        ],
+      },
+    },
+  ],
+  llm: baseLlm,
+  signal: new AbortController().signal,
+};
+
+// ---- Investigation Agent テスト ----
+
+describe("runInvestigationAgent", () => {
+  test("正常系: agent_started → chunk* → agent_completed のイベントシーケンスを発行する", async () => {
+    // 有効な JSON を複数チャンクに分割して渡す
+    const chunk1 = validInvestigationJson.slice(0, 20);
+    const chunk2 = validInvestigationJson.slice(20);
+    const deps = makeDeps([chunk1, chunk2]);
+    const result = await runInvestigationAgent(
+      { ...baseInvestigationInput },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+
+    const kinds = deps.capturedEvents.map((e) => e.kind);
+    expect(kinds[0]).toBe("agent_started");
+    expect(kinds.slice(1, -1)).toEqual([
+      "agent_output_chunk",
+      "agent_output_chunk",
+    ]);
+    expect(kinds[kinds.length - 1]).toBe("agent_completed");
+  });
+
+  test("正常系: LLM 出力を JSON パースして output を返す", async () => {
+    const deps = makeDeps([validInvestigationJson]);
+    const result = await runInvestigationAgent(
+      { ...baseInvestigationInput },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.perspective).toBe("strategy");
+      expect(result.output.findings).toHaveLength(1);
+    }
+  });
+
+  test("正常系: DB 更新は「running → completed」の順で行われる", async () => {
+    const deps = makeDeps([validInvestigationJson]);
+    await runInvestigationAgent({ ...baseInvestigationInput }, deps);
+
+    const statuses = deps.capturedPatches.map((p) => p.patch.status);
+    expect(statuses).toEqual(["running", "completed"]);
+  });
+
+  test("正常系: DB UPDATE が agent_started より前に実行される（副作用順序）", async () => {
+    const order: string[] = [];
+    const deps = makeDeps([validInvestigationJson], {
+      updateAgentExecution: async (_id, _patch) => {
+        order.push("db");
+      },
+      onEvent: (event) => {
+        order.push(event.kind);
+      },
+    });
+
+    await runInvestigationAgent({ ...baseInvestigationInput }, deps);
+
+    // DB UPDATE → agent_started の順序を確認
+    expect(order[0]).toBe("db");
+    expect(order[1]).toBe("agent_started");
+  });
+
+  test("LLM エラー → agent_failed('llm_error') を発行し { success: false } を返す", async () => {
+    // LlmError を発生させる stream を注入
+    const { LlmError } = await import("./llm-client.ts");
+
+    // biome-ignore lint/correctness/useYield: throw のみのストリームテスト用ジェネレーター
+    async function* errorStream(): AsyncIterable<string> {
+      throw new LlmError("llm_error", "API error");
+    }
+
+    const deps = makeDeps([], { stream: () => errorStream() });
+    const result = await runInvestigationAgent(
+      { ...baseInvestigationInput },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBe("llm_error");
+    }
+
+    const failEvent = deps.capturedEvents.find(
+      (e) => e.kind === "agent_failed",
+    );
+    expect(failEvent).toBeDefined();
+    if (failEvent?.kind === "agent_failed") {
+      expect(failEvent.reason).toBe("llm_error");
+    }
+  });
+
+  test("出力 JSON パース失敗 → agent_failed('output_parse_error') を発行する", async () => {
+    const deps = makeDeps(["not valid json"]);
+    const result = await runInvestigationAgent(
+      { ...baseInvestigationInput },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBe("output_parse_error");
+    }
+
+    const failEvent = deps.capturedEvents.find(
+      (e) => e.kind === "agent_failed",
+    );
+    expect(failEvent).toBeDefined();
+    if (failEvent?.kind === "agent_failed") {
+      expect(failEvent.reason).toBe("output_parse_error");
+    }
+  });
+
+  test("AbortError → agent_failed('timeout') を発行する", async () => {
+    const controller = new AbortController();
+
+    // biome-ignore lint/correctness/useYield: throw のみのストリームテスト用ジェネレーター
+    async function* abortedStream(): AsyncIterable<string> {
+      controller.abort();
+      throw new DOMException("Aborted", "AbortError");
+    }
+
+    const deps = makeDeps([], { stream: () => abortedStream() });
+    const result = await runInvestigationAgent(
+      { ...baseInvestigationInput, signal: controller.signal },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBe("timeout");
+    }
+
+    const failEvent = deps.capturedEvents.find(
+      (e) => e.kind === "agent_failed",
+    );
+    expect(failEvent).toBeDefined();
+    if (failEvent?.kind === "agent_failed") {
+      expect(failEvent.reason).toBe("timeout");
+    }
+  });
+
+  test("失敗時: DB が failed で更新された後にイベントが発行される（副作用順序）", async () => {
+    const order: string[] = [];
+    const deps = makeDeps(["invalid json"], {
+      updateAgentExecution: async (_id, patch) => {
+        order.push(`db:${patch.status}`);
+      },
+      onEvent: (event) => {
+        order.push(event.kind);
+      },
+    });
+
+    await runInvestigationAgent({ ...baseInvestigationInput }, deps);
+
+    const failDbIdx = order.indexOf("db:failed");
+    const failEventIdx = order.indexOf("agent_failed");
+    expect(failDbIdx).toBeGreaterThanOrEqual(0);
+    expect(failEventIdx).toBeGreaterThan(failDbIdx);
+  });
+});
+
+// ---- Integration Agent テスト ----
+
+describe("runIntegrationAgent", () => {
+  test("正常系: agent_started → chunk* → agent_completed のイベントシーケンスを発行する", async () => {
+    const deps = makeDeps([validIntegrationRaw]);
+    const result = await runIntegrationAgent({ ...baseIntegrationInput }, deps);
+
+    expect(result.success).toBe(true);
+
+    const kinds = deps.capturedEvents.map((e) => e.kind);
+    expect(kinds[0]).toBe("agent_started");
+    expect(kinds[kinds.length - 1]).toBe("agent_completed");
+  });
+
+  test("正常系: Markdown と構造化出力の両方を返す", async () => {
+    const deps = makeDeps([validIntegrationRaw]);
+    const result = await runIntegrationAgent({ ...baseIntegrationInput }, deps);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.markdown).toContain("Markdown");
+      expect(result.output.matrix).toHaveLength(1);
+      expect(result.output.overall_insights).toHaveLength(1);
+    }
+  });
+
+  test("出力パース失敗 → agent_failed('output_parse_error')", async () => {
+    const deps = makeDeps(["Markdown only, no JSON"]);
+    const result = await runIntegrationAgent({ ...baseIntegrationInput }, deps);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBe("output_parse_error");
+    }
+  });
+
+  test("LLM エラー → agent_failed('llm_error')", async () => {
+    const { LlmError } = await import("./llm-client.ts");
+
+    // biome-ignore lint/correctness/useYield: throw のみのストリームテスト用ジェネレーター
+    async function* errorStream(): AsyncIterable<string> {
+      throw new LlmError("llm_error", "API error");
+    }
+
+    const deps = makeDeps([], { stream: () => errorStream() });
+    const result = await runIntegrationAgent({ ...baseIntegrationInput }, deps);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).toBe("llm_error");
+    }
+  });
+
+  test("investigation_results プレースホルダに成功した調査結果が展開される", async () => {
+    let capturedSystem = "";
+
+    async function* captureStream(input: LlmInput): AsyncIterable<string> {
+      capturedSystem = input.system;
+      yield validIntegrationRaw;
+    }
+
+    const deps = makeDeps([], { stream: (input) => captureStream(input) });
+    await runIntegrationAgent({ ...baseIntegrationInput }, deps);
+
+    expect(capturedSystem).toContain("strategy");
+  });
+});

--- a/packages/agent-core/src/agent.test.ts
+++ b/packages/agent-core/src/agent.test.ts
@@ -361,6 +361,7 @@ describe("runIntegrationAgent", () => {
     const deps = makeDeps([], { stream: (input) => captureStream(input) });
     await runIntegrationAgent({ ...baseIntegrationInput }, deps);
 
-    expect(capturedSystem).toContain("strategy");
+    expect(capturedSystem).toContain("CompanyA");
+    expect(capturedSystem).toContain('"perspective"');
   });
 });

--- a/packages/agent-core/src/agent.test.ts
+++ b/packages/agent-core/src/agent.test.ts
@@ -200,7 +200,7 @@ describe("runInvestigationAgent", () => {
 
   test("LLM エラー → agent_failed('llm_error') を発行し { success: false } を返す", async () => {
     // LlmError を発生させる stream を注入
-    const { LlmError } = await import("./llm-client.ts");
+    const { LlmError } = await import("./llm-error.ts");
 
     // biome-ignore lint/correctness/useYield: throw のみのストリームテスト用ジェネレーター
     async function* errorStream(): AsyncIterable<string> {
@@ -334,7 +334,7 @@ describe("runIntegrationAgent", () => {
   });
 
   test("LLM エラー → agent_failed('llm_error')", async () => {
-    const { LlmError } = await import("./llm-client.ts");
+    const { LlmError } = await import("./llm-error.ts");
 
     // biome-ignore lint/correctness/useYield: throw のみのストリームテスト用ジェネレーター
     async function* errorStream(): AsyncIterable<string> {

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -84,10 +84,10 @@ function substituteTemplate(
   template: string,
   vars: Record<string, string>,
 ): string {
-  return template.replace(
-    /\{\{(\w+)\}\}/g,
-    (_, key: string) => vars[key] ?? `{{${key}}}`,
-  );
+  return template.replace(/\{\{(\w+)\}\}/g, (_match, key: string) => {
+    if (!(key in vars)) throw new Error(`Unknown template key: {{${key}}}`);
+    return vars[key] as string;
+  });
 }
 
 function buildInvestigationSystem(
@@ -156,11 +156,19 @@ function isInvestigationOutput(
 function isIntegrationOutput(value: unknown): value is IntegrationAgentOutput {
   if (typeof value !== "object" || value === null) return false;
   const obj = value as Record<string, unknown>;
-  return (
-    Array.isArray(obj.matrix) &&
-    Array.isArray(obj.overall_insights) &&
-    Array.isArray(obj.missing)
-  );
+  if (
+    !Array.isArray(obj.matrix) ||
+    !Array.isArray(obj.overall_insights) ||
+    !Array.isArray(obj.missing)
+  )
+    return false;
+  for (const cell of obj.matrix) {
+    if (typeof cell !== "object" || cell === null) return false;
+    const c = cell as Record<string, unknown>;
+    if (typeof c.perspective !== "string" || !Array.isArray(c.cells))
+      return false;
+  }
+  return true;
 }
 
 function parseInvestigationOutput(raw: string): InvestigationAgentOutput {

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -21,7 +21,7 @@ import type {
 } from "@agent-team-studio/shared";
 import type { AgentEvent } from "./events.ts";
 import type { LlmInput } from "./llm-client.ts";
-import { LlmError } from "./llm-client.ts";
+import { LlmError } from "./llm-error.ts";
 
 // ---------- 公開型 ----------
 

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -167,6 +167,16 @@ function isIntegrationOutput(value: unknown): value is IntegrationAgentOutput {
     const c = cell as Record<string, unknown>;
     if (typeof c.perspective !== "string" || !Array.isArray(c.cells))
       return false;
+    for (const item of c.cells) {
+      if (typeof item !== "object" || item === null) return false;
+      const i = item as Record<string, unknown>;
+      if (
+        typeof i.competitor !== "string" ||
+        typeof i.summary !== "string" ||
+        typeof i.source_evidence_level !== "string"
+      )
+        return false;
+    }
   }
   return true;
 }

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -18,6 +18,7 @@ import type {
   InvestigationAgentDefinition,
   InvestigationAgentOutput,
   LlmDefaults,
+  MissingPerspective,
 } from "@agent-team-studio/shared";
 import type { AgentEvent } from "./events.ts";
 import type { LlmInput } from "./llm-client.ts";
@@ -153,7 +154,10 @@ function isInvestigationOutput(
   return true;
 }
 
-const MISSING_REASONS = ["agent_failed", "insufficient_evidence"] as const;
+const MISSING_REASONS = [
+  "agent_failed",
+  "insufficient_evidence",
+] as const satisfies MissingPerspective["reason"][];
 
 function isIntegrationOutput(value: unknown): value is IntegrationAgentOutput {
   if (typeof value !== "object" || value === null) return false;

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -13,6 +13,7 @@ import type {
   AgentStatus,
   CompetitorAnalysisParameters,
   CompetitorPerspectiveKey,
+  EvidenceLevel,
   IntegrationAgentDefinition,
   IntegrationAgentOutput,
   InvestigationAgentDefinition,
@@ -129,12 +130,12 @@ const PERSPECTIVE_KEYS: readonly string[] = [
   "partnership",
 ] satisfies CompetitorPerspectiveKey[];
 
-const EVIDENCE_LEVELS: readonly string[] = [
+const EVIDENCE_LEVELS = [
   "strong",
   "moderate",
   "weak",
   "insufficient",
-];
+] as const satisfies EvidenceLevel[];
 
 function isInvestigationOutput(
   value: unknown,
@@ -148,7 +149,7 @@ function isInvestigationOutput(
     const finding = f as Record<string, unknown>;
     if (typeof finding.competitor !== "string") return false;
     if (!Array.isArray(finding.points)) return false;
-    if (!EVIDENCE_LEVELS.includes(finding.evidence_level as string))
+    if (!EVIDENCE_LEVELS.includes(finding.evidence_level as EvidenceLevel))
       return false;
   }
   return true;
@@ -182,7 +183,7 @@ function isIntegrationOutput(value: unknown): value is IntegrationAgentOutput {
       if (
         typeof i.competitor !== "string" ||
         typeof i.summary !== "string" ||
-        !EVIDENCE_LEVELS.includes(i.source_evidence_level as string)
+        !EVIDENCE_LEVELS.includes(i.source_evidence_level as EvidenceLevel)
       )
         return false;
     }

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -153,6 +153,8 @@ function isInvestigationOutput(
   return true;
 }
 
+const MISSING_REASONS = ["agent_failed", "insufficient_evidence"] as const;
+
 function isIntegrationOutput(value: unknown): value is IntegrationAgentOutput {
   if (typeof value !== "object" || value === null) return false;
   const obj = value as Record<string, unknown>;
@@ -165,7 +167,10 @@ function isIntegrationOutput(value: unknown): value is IntegrationAgentOutput {
   for (const cell of obj.matrix) {
     if (typeof cell !== "object" || cell === null) return false;
     const c = cell as Record<string, unknown>;
-    if (typeof c.perspective !== "string" || !Array.isArray(c.cells))
+    if (
+      !PERSPECTIVE_KEYS.includes(c.perspective as string) ||
+      !Array.isArray(c.cells)
+    )
       return false;
     for (const item of c.cells) {
       if (typeof item !== "object" || item === null) return false;
@@ -173,10 +178,22 @@ function isIntegrationOutput(value: unknown): value is IntegrationAgentOutput {
       if (
         typeof i.competitor !== "string" ||
         typeof i.summary !== "string" ||
-        typeof i.source_evidence_level !== "string"
+        !EVIDENCE_LEVELS.includes(i.source_evidence_level as string)
       )
         return false;
     }
+  }
+  for (const insight of obj.overall_insights) {
+    if (typeof insight !== "string") return false;
+  }
+  for (const m of obj.missing) {
+    if (typeof m !== "object" || m === null) return false;
+    const mp = m as Record<string, unknown>;
+    if (
+      !PERSPECTIVE_KEYS.includes(mp.perspective as string) ||
+      !(MISSING_REASONS as readonly string[]).includes(mp.reason as string)
+    )
+      return false;
   }
   return true;
 }

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -1,0 +1,407 @@
+/**
+ * Investigation Agent / Integration Agent の実行。
+ *
+ * 各エージェントは LLM ストリームを受け取り、DB 更新とイベント発行を行う。
+ * 副作用は「DB UPDATE → イベント発行」の順序を保証する（agent-execution.md §4）。
+ * 依存はすべて AgentDeps で注入するため、テスト時に差し替え可能。
+ *
+ * SSoT: docs/design/agent-execution.md / docs/design/llm-integration.md
+ */
+
+import type {
+  AgentFailReason,
+  AgentStatus,
+  CompetitorAnalysisParameters,
+  CompetitorPerspectiveKey,
+  IntegrationAgentDefinition,
+  IntegrationAgentOutput,
+  InvestigationAgentDefinition,
+  InvestigationAgentOutput,
+  LlmDefaults,
+} from "@agent-team-studio/shared";
+import type { AgentEvent } from "./events.ts";
+import type { LlmInput } from "./llm-client.ts";
+import { LlmError } from "./llm-client.ts";
+
+// ---------- 公開型 ----------
+
+/** agent.ts が必要とする外部依存の注入口。テスト時はすべて差し替え可能。 */
+export type AgentDeps = {
+  stream: (input: LlmInput, signal?: AbortSignal) => AsyncIterable<string>;
+  updateAgentExecution: (
+    id: string,
+    patch: AgentExecutionPatch,
+  ) => Promise<void>;
+  onEvent: (event: AgentEvent) => void;
+};
+
+/** agent_executions テーブルへの書き込みパッチ型。 */
+export type AgentExecutionPatch = {
+  status: AgentStatus;
+  output?: InvestigationAgentOutput | IntegrationAgentOutput;
+  errorMessage?: string;
+  startedAt?: Date;
+  completedAt?: Date;
+};
+
+/** Investigation Agent 実行の入力。 */
+export type InvestigationAgentRunInput = {
+  agentExecutionId: string;
+  agentId: string;
+  definition: InvestigationAgentDefinition;
+  parameters: CompetitorAnalysisParameters;
+  llm: LlmDefaults;
+  signal: AbortSignal;
+};
+
+/** Integration Agent 実行の入力。 */
+export type IntegrationAgentRunInput = {
+  agentExecutionId: string;
+  agentId: string;
+  definition: IntegrationAgentDefinition;
+  parameters: CompetitorAnalysisParameters;
+  successfulInvestigations: Array<{
+    agentId: string;
+    output: InvestigationAgentOutput;
+  }>;
+  llm: LlmDefaults;
+  signal: AbortSignal;
+};
+
+/** Investigation Agent の実行結果。 */
+export type InvestigationResult =
+  | { success: true; output: InvestigationAgentOutput }
+  | { success: false; reason: AgentFailReason };
+
+/** Integration Agent の実行結果。 */
+export type IntegrationResult =
+  | { success: true; output: IntegrationAgentOutput; markdown: string }
+  | { success: false; reason: AgentFailReason };
+
+// ---------- プロンプト展開 ----------
+
+function substituteTemplate(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  return template.replace(
+    /\{\{(\w+)\}\}/g,
+    (_, key: string) => vars[key] ?? `{{${key}}}`,
+  );
+}
+
+function buildInvestigationSystem(
+  template: string,
+  def: InvestigationAgentDefinition,
+  params: CompetitorAnalysisParameters,
+): string {
+  return substituteTemplate(template, {
+    perspective_name_ja: def.specialization.perspective_name_ja,
+    perspective_description: def.specialization.perspective_description,
+    competitors: params.competitors.join(", "),
+    reference_or_empty: params.reference ?? "（参考情報なし）",
+  });
+}
+
+function buildIntegrationSystem(
+  template: string,
+  params: CompetitorAnalysisParameters,
+  investigations: Array<{ output: InvestigationAgentOutput }>,
+): string {
+  return substituteTemplate(template, {
+    competitors: params.competitors.join(", "),
+    investigation_results: JSON.stringify(
+      investigations.map((i) => i.output),
+      null,
+      2,
+    ),
+    reference_or_empty: params.reference ?? "（参考情報なし）",
+  });
+}
+
+// ---------- 出力パース ----------
+
+const PERSPECTIVE_KEYS: readonly string[] = [
+  "strategy",
+  "product",
+  "investment",
+  "partnership",
+] satisfies CompetitorPerspectiveKey[];
+
+const EVIDENCE_LEVELS: readonly string[] = [
+  "strong",
+  "moderate",
+  "weak",
+  "insufficient",
+];
+
+function isInvestigationOutput(
+  value: unknown,
+): value is InvestigationAgentOutput {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (!PERSPECTIVE_KEYS.includes(obj.perspective as string)) return false;
+  if (!Array.isArray(obj.findings)) return false;
+  for (const f of obj.findings) {
+    if (typeof f !== "object" || f === null) return false;
+    const finding = f as Record<string, unknown>;
+    if (typeof finding.competitor !== "string") return false;
+    if (!Array.isArray(finding.points)) return false;
+    if (!EVIDENCE_LEVELS.includes(finding.evidence_level as string))
+      return false;
+  }
+  return true;
+}
+
+function isIntegrationOutput(value: unknown): value is IntegrationAgentOutput {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    Array.isArray(obj.matrix) &&
+    Array.isArray(obj.overall_insights) &&
+    Array.isArray(obj.missing)
+  );
+}
+
+function parseInvestigationOutput(raw: string): InvestigationAgentOutput {
+  const cleaned = raw
+    .trim()
+    .replace(/^```json\s*\n?/, "")
+    .replace(/\n?```\s*$/, "");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    throw new Error("Invalid JSON in investigation output");
+  }
+  if (!isInvestigationOutput(parsed)) {
+    throw new Error("Invalid investigation output structure");
+  }
+  return parsed;
+}
+
+function parseIntegrationOutput(raw: string): {
+  markdown: string;
+  structured: IntegrationAgentOutput;
+} {
+  // "matrix" キーの最後の出現から JSON ブロックの開始位置を特定する
+  const matrixKeyIdx = raw.lastIndexOf('"matrix"');
+  if (matrixKeyIdx === -1)
+    throw new Error('No "matrix" field in integration output');
+
+  let jsonStart = matrixKeyIdx - 1;
+  while (jsonStart >= 0 && raw[jsonStart] !== "{") jsonStart--;
+  if (jsonStart < 0) throw new Error("No opening brace before matrix field");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.slice(jsonStart));
+  } catch {
+    throw new Error("Invalid JSON in integration output");
+  }
+  if (!isIntegrationOutput(parsed)) {
+    throw new Error("Invalid integration output structure");
+  }
+
+  return {
+    markdown: raw.slice(0, jsonStart).trim(),
+    structured: parsed,
+  };
+}
+
+// ---------- エラー判定ヘルパー ----------
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+function toAgentFailReason(err: unknown): AgentFailReason {
+  if (isAbortError(err)) return "timeout";
+  if (err instanceof LlmError) return err.failReason;
+  return "internal_error";
+}
+
+// ---------- エージェント実行 ----------
+
+/**
+ * Investigation Agent を実行する。
+ *
+ * DB 更新 → イベント発行の順序で副作用を起こす。失敗時も同様の順序で `agent_failed` を発行する。
+ */
+export async function runInvestigationAgent(
+  input: InvestigationAgentRunInput,
+  deps: AgentDeps,
+): Promise<InvestigationResult> {
+  const startedAt = new Date();
+  await deps.updateAgentExecution(input.agentExecutionId, {
+    status: "running",
+    startedAt,
+  });
+  deps.onEvent({
+    kind: "agent_started",
+    agentId: input.agentId,
+    startedAt: startedAt.toISOString(),
+  });
+
+  const chunks: string[] = [];
+
+  try {
+    const llmInput: LlmInput = {
+      model: input.llm.model,
+      system: buildInvestigationSystem(
+        input.definition.system_prompt_template,
+        input.definition,
+        input.parameters,
+      ),
+      user: "指示に従って JSON を出力してください。",
+      temperature: input.llm.temperature_by_role.investigation,
+      max_tokens: input.llm.max_tokens_by_role.investigation,
+    };
+
+    for await (const chunk of deps.stream(llmInput, input.signal)) {
+      chunks.push(chunk);
+      deps.onEvent({
+        kind: "agent_output_chunk",
+        agentId: input.agentId,
+        chunk,
+      });
+    }
+  } catch (err) {
+    return handleAgentFailure(err, input.agentExecutionId, input.agentId, deps);
+  }
+
+  let output: InvestigationAgentOutput;
+  try {
+    output = parseInvestigationOutput(chunks.join(""));
+  } catch {
+    return handleParseFailure(input.agentExecutionId, input.agentId, deps);
+  }
+
+  const completedAt = new Date();
+  await deps.updateAgentExecution(input.agentExecutionId, {
+    status: "completed",
+    output,
+    completedAt,
+  });
+  deps.onEvent({
+    kind: "agent_completed",
+    agentId: input.agentId,
+    completedAt: completedAt.toISOString(),
+  });
+  return { success: true, output };
+}
+
+/**
+ * Integration Agent を実行する。
+ *
+ * 出力は Markdown と構造化 JSON の両方を返す。
+ */
+export async function runIntegrationAgent(
+  input: IntegrationAgentRunInput,
+  deps: AgentDeps,
+): Promise<IntegrationResult> {
+  const startedAt = new Date();
+  await deps.updateAgentExecution(input.agentExecutionId, {
+    status: "running",
+    startedAt,
+  });
+  deps.onEvent({
+    kind: "agent_started",
+    agentId: input.agentId,
+    startedAt: startedAt.toISOString(),
+  });
+
+  const chunks: string[] = [];
+
+  try {
+    const llmInput: LlmInput = {
+      model: input.llm.model,
+      system: buildIntegrationSystem(
+        input.definition.system_prompt_template,
+        input.parameters,
+        input.successfulInvestigations,
+      ),
+      user: "指示に従って Markdown レポートと内部 JSON を出力してください。",
+      temperature: input.llm.temperature_by_role.integration,
+      max_tokens: input.llm.max_tokens_by_role.integration,
+    };
+
+    for await (const chunk of deps.stream(llmInput, input.signal)) {
+      chunks.push(chunk);
+      deps.onEvent({
+        kind: "agent_output_chunk",
+        agentId: input.agentId,
+        chunk,
+      });
+    }
+  } catch (err) {
+    return handleAgentFailure(err, input.agentExecutionId, input.agentId, deps);
+  }
+
+  let markdown: string;
+  let structured: IntegrationAgentOutput;
+  try {
+    const parsed = parseIntegrationOutput(chunks.join(""));
+    markdown = parsed.markdown;
+    structured = parsed.structured;
+  } catch {
+    return handleParseFailure(input.agentExecutionId, input.agentId, deps);
+  }
+
+  const completedAt = new Date();
+  await deps.updateAgentExecution(input.agentExecutionId, {
+    status: "completed",
+    output: structured,
+    completedAt,
+  });
+  deps.onEvent({
+    kind: "agent_completed",
+    agentId: input.agentId,
+    completedAt: completedAt.toISOString(),
+  });
+  return { success: true, output: structured, markdown };
+}
+
+// ---------- 共通失敗処理 ----------
+
+async function handleAgentFailure(
+  err: unknown,
+  agentExecutionId: string,
+  agentId: string,
+  deps: AgentDeps,
+): Promise<{ success: false; reason: AgentFailReason }> {
+  const completedAt = new Date();
+  const reason = toAgentFailReason(err);
+  await deps.updateAgentExecution(agentExecutionId, {
+    status: "failed",
+    errorMessage: err instanceof Error ? err.message : String(err),
+    completedAt,
+  });
+  deps.onEvent({
+    kind: "agent_failed",
+    agentId,
+    reason,
+    failedAt: completedAt.toISOString(),
+  });
+  return { success: false, reason };
+}
+
+async function handleParseFailure(
+  agentExecutionId: string,
+  agentId: string,
+  deps: AgentDeps,
+): Promise<{ success: false; reason: "output_parse_error" }> {
+  const completedAt = new Date();
+  await deps.updateAgentExecution(agentExecutionId, {
+    status: "failed",
+    errorMessage: "output_parse_error",
+    completedAt,
+  });
+  deps.onEvent({
+    kind: "agent_failed",
+    agentId,
+    reason: "output_parse_error",
+    failedAt: completedAt.toISOString(),
+  });
+  return { success: false, reason: "output_parse_error" };
+}

--- a/packages/agent-core/src/constants.ts
+++ b/packages/agent-core/src/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * agent-core のタイムアウト値 SSoT。
+ *
+ * docs/design/agent-execution.md §7 の値を転記。実装後は本ファイルが SSoT となる。
+ * Template 単位でのカスタマイズは v2 以降（MVP ではすべてのエージェントで共通値を使用）。
+ */
+
+/** エージェント単位のタイムアウト（ms）。超過時は AbortSignal で LLM 呼び出しを中断する。 */
+export const AGENT_TIMEOUT_MS = 300_000;
+
+/** Execution 全体のタイムアウト（ms）。超過時はすべての実行中エージェントを中断する。 */
+export const EXECUTION_TIMEOUT_MS = 1_500_000;

--- a/packages/agent-core/src/engine.test.ts
+++ b/packages/agent-core/src/engine.test.ts
@@ -391,4 +391,25 @@ describe("runExecution", () => {
       expect(failEvent.reason).toBe("timeout");
     }
   });
+
+  test("insertResult が throw → execution_failed('internal_error') を発行し execution が running のまま残らない", async () => {
+    const deps = makeFakeDeps(undefined, {
+      insertResultFn: async () => {
+        throw new Error("DB connection error");
+      },
+    });
+
+    await expect(runExecution(baseInput, deps)).rejects.toThrow(
+      "DB connection error",
+    );
+
+    const failEvent = deps.events.find((e) => e.kind === "execution_failed");
+    expect(failEvent).toBeDefined();
+    if (failEvent?.kind === "execution_failed") {
+      expect(failEvent.reason).toBe("internal_error");
+    }
+
+    const finalPatch = deps.executionPatches[deps.executionPatches.length - 1];
+    expect(finalPatch?.patch.status).toBe("failed");
+  });
 });

--- a/packages/agent-core/src/engine.test.ts
+++ b/packages/agent-core/src/engine.test.ts
@@ -281,13 +281,12 @@ describe("runExecution", () => {
       input: LlmInput,
       signal?: AbortSignal,
     ): AsyncIterable<string> => {
-      if (input.system.includes("調査")) {
-        callCount++;
-        // 1回目は失敗、2回目以降は成功
-        if (callCount === 1) return makeStream(["invalid json"])(input, signal);
-        return investigationStream(input, signal);
-      }
-      return integrationStream(input, signal);
+      if (input.system.includes('"findings"'))
+        return integrationStream(input, signal);
+      callCount++;
+      // 1回目は失敗、2回目以降は成功
+      if (callCount === 1) return makeStream(["invalid json"])(input, signal);
+      return investigationStream(input, signal);
     };
 
     const deps = makeFakeDeps(partialStream);
@@ -305,10 +304,10 @@ describe("runExecution", () => {
       input: LlmInput,
       signal?: AbortSignal,
     ): AsyncIterable<string> => {
-      if (input.system.includes("調査"))
-        return investigationStream(input, signal);
-      // Integration は無効出力（パース失敗）
-      return makeStream(["no matrix here"])(input, signal);
+      if (input.system.includes('"findings"'))
+        // Integration は無効出力（パース失敗）
+        return makeStream(["no matrix here"])(input, signal);
+      return investigationStream(input, signal);
     };
 
     const deps = makeFakeDeps(mixedStream);

--- a/packages/agent-core/src/engine.test.ts
+++ b/packages/agent-core/src/engine.test.ts
@@ -1,0 +1,394 @@
+/**
+ * engine.ts のユニットテスト。
+ *
+ * すべての外部依存（DB ops, LLM stream, agent runners）を fake で注入し、
+ * engine のオーケストレーションロジックのみを検証する。
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentRole,
+  CompetitorAnalysisParameters,
+  TemplateDefinition,
+} from "@agent-team-studio/shared";
+import type { AgentExecutionPatch } from "./agent.ts";
+import type {
+  EngineRunDeps,
+  EngineRunInput,
+  ExecutionUpdatePatch,
+  InsertResultInput,
+} from "./engine.ts";
+import { runExecution } from "./engine.ts";
+import type { AgentEvent } from "./events.ts";
+import type { LlmInput } from "./llm-client.ts";
+
+// ---- フィクスチャ ----
+
+const baseLlm = {
+  model: "claude-sonnet-4-6",
+  temperature_by_role: { investigation: 0.3, integration: 0.2 },
+  max_tokens_by_role: { investigation: 2048, integration: 4096 },
+};
+
+const baseParams: CompetitorAnalysisParameters = {
+  competitors: ["CompanyA", "CompanyB"],
+};
+
+const templateDefinition: TemplateDefinition = {
+  schema_version: "1",
+  input_schema: {},
+  llm: baseLlm,
+  agents: [
+    {
+      role: "investigation",
+      agent_id: "investigation:strategy",
+      specialization: {
+        perspective_key: "strategy",
+        perspective_name_ja: "戦略",
+        perspective_description: "事業戦略",
+      },
+      system_prompt_template: "調査プロンプト {{competitors}}",
+    },
+    {
+      role: "investigation",
+      agent_id: "investigation:product",
+      specialization: {
+        perspective_key: "product",
+        perspective_name_ja: "製品",
+        perspective_description: "製品情報",
+      },
+      system_prompt_template: "調査プロンプト {{competitors}}",
+    },
+    {
+      role: "integration",
+      agent_id: "integration:matrix",
+      system_prompt_template: "統合プロンプト {{investigation_results}}",
+    },
+  ],
+};
+
+const agentExecutions: EngineRunInput["agentExecutions"] = [
+  {
+    id: "ae-1",
+    agentId: "investigation:strategy",
+    role: "investigation" as AgentRole,
+  },
+  {
+    id: "ae-2",
+    agentId: "investigation:product",
+    role: "investigation" as AgentRole,
+  },
+  {
+    id: "ae-3",
+    agentId: "integration:matrix",
+    role: "integration" as AgentRole,
+  },
+];
+
+const baseInput: EngineRunInput = {
+  executionId: "exec-1",
+  parameters: baseParams,
+  templateDefinition,
+  agentExecutions,
+};
+
+const successInvestigationOutput = {
+  perspective: "strategy" as const,
+  findings: [
+    {
+      competitor: "CompanyA",
+      points: ["点1"],
+      evidence_level: "strong" as const,
+    },
+  ],
+};
+
+const successIntegrationOutput = {
+  matrix: [
+    {
+      perspective: "strategy" as const,
+      cells: [
+        {
+          competitor: "CompanyA",
+          summary: "要約",
+          source_evidence_level: "strong" as const,
+        },
+      ],
+    },
+  ],
+  overall_insights: ["所見1"],
+  missing: [],
+};
+
+const validIntegrationRaw = `## レポート\n\n${JSON.stringify(successIntegrationOutput)}`;
+
+// ---- fake stream ヘルパー ----
+
+function makeStream(
+  chunks: string[],
+): (input: LlmInput, signal?: AbortSignal) => AsyncIterable<string> {
+  return async function* () {
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  };
+}
+
+// Investigation Agent が成功するストリーム
+const investigationStream = makeStream([
+  JSON.stringify(successInvestigationOutput),
+]);
+// Integration Agent が成功するストリーム
+const integrationStream = makeStream([validIntegrationRaw]);
+
+// ---- fake deps ヘルパー ----
+
+type FakeDeps = EngineRunDeps & {
+  executionPatches: Array<{ id: string; patch: ExecutionUpdatePatch }>;
+  agentPatches: Array<{ id: string; patch: AgentExecutionPatch }>;
+  insertedResults: InsertResultInput[];
+  events: AgentEvent[];
+};
+
+function makeFakeDeps(
+  streamFn?: (input: LlmInput, signal?: AbortSignal) => AsyncIterable<string>,
+  opts?: {
+    insertResultFn?: (input: InsertResultInput) => Promise<string>;
+    agentTimeoutMs?: number;
+    executionTimeoutMs?: number;
+  },
+): FakeDeps {
+  const executionPatches: Array<{ id: string; patch: ExecutionUpdatePatch }> =
+    [];
+  const agentPatches: Array<{ id: string; patch: AgentExecutionPatch }> = [];
+  const insertedResults: InsertResultInput[] = [];
+  const events: AgentEvent[] = [];
+
+  // デフォルト: Investigation → 成功JSON, Integration → validIntegrationRaw
+  const defaultStream = (
+    input: LlmInput,
+    signal?: AbortSignal,
+  ): AsyncIterable<string> => {
+    // system プロンプトの内容で agent 種別を判定
+    if (input.system.includes("調査"))
+      return investigationStream(input, signal);
+    return integrationStream(input, signal);
+  };
+
+  return {
+    updateExecution: async (id, patch) => {
+      executionPatches.push({ id, patch });
+    },
+    updateAgentExecution: async (id, patch) => {
+      agentPatches.push({ id, patch });
+    },
+    insertResult:
+      opts?.insertResultFn ??
+      (async (input) => {
+        insertedResults.push(input);
+        return "result-1";
+      }),
+    onEvent: (event) => {
+      events.push(event);
+    },
+    _stream: streamFn ?? defaultStream,
+    agentTimeoutMs: opts?.agentTimeoutMs,
+    executionTimeoutMs: opts?.executionTimeoutMs,
+    executionPatches,
+    agentPatches,
+    insertedResults,
+    events,
+  };
+}
+
+// ---- テスト ----
+
+describe("runExecution", () => {
+  test("全 Investigation 成功 + Integration 成功 → execution_completed を発行し Result を INSERT する", async () => {
+    const deps = makeFakeDeps();
+    await runExecution(baseInput, deps);
+
+    const completedEvent = deps.events.find(
+      (e) => e.kind === "execution_completed",
+    );
+    expect(completedEvent).toBeDefined();
+    if (completedEvent?.kind === "execution_completed") {
+      expect(completedEvent.resultId).toBe("result-1");
+    }
+
+    expect(deps.insertedResults).toHaveLength(1);
+    expect(deps.insertedResults[0]?.executionId).toBe("exec-1");
+  });
+
+  test("全 Investigation 成功 + Integration 成功 → Execution.status が completed に更新される", async () => {
+    const deps = makeFakeDeps();
+    await runExecution(baseInput, deps);
+
+    const finalPatch = deps.executionPatches[deps.executionPatches.length - 1];
+    expect(finalPatch?.patch.status).toBe("completed");
+  });
+
+  test("DB UPDATE → execution_completed イベント発行の順序を保証する", async () => {
+    const order: string[] = [];
+    const deps = makeFakeDeps();
+    const origUpdate = deps.updateExecution;
+    deps.updateExecution = async (id, patch) => {
+      order.push(`db:${patch.status}`);
+      return origUpdate(id, patch);
+    };
+    const origOnEvent = deps.onEvent;
+    deps.onEvent = (event) => {
+      order.push(event.kind);
+      origOnEvent(event);
+    };
+
+    await runExecution(baseInput, deps);
+
+    const dbCompletedIdx = order.lastIndexOf("db:completed");
+    const eventCompletedIdx = order.indexOf("execution_completed");
+    expect(dbCompletedIdx).toBeGreaterThanOrEqual(0);
+    expect(eventCompletedIdx).toBeGreaterThan(dbCompletedIdx);
+  });
+
+  test("全 Investigation 失敗 → execution_failed('all_investigations_failed') を発行する", async () => {
+    // 全 agent で無効 JSON を返す（parse 失敗 → agent_failed）
+    const failStream = makeStream(["invalid json for all"]);
+    const deps = makeFakeDeps(failStream);
+    await runExecution(baseInput, deps);
+
+    const failEvent = deps.events.find((e) => e.kind === "execution_failed");
+    expect(failEvent).toBeDefined();
+    if (failEvent?.kind === "execution_failed") {
+      expect(failEvent.reason).toBe("all_investigations_failed");
+    }
+
+    // Result は INSERT されない
+    expect(deps.insertedResults).toHaveLength(0);
+  });
+
+  test("全 Investigation 失敗 → Execution.status が failed に更新される", async () => {
+    const failStream = makeStream(["invalid json"]);
+    const deps = makeFakeDeps(failStream);
+    await runExecution(baseInput, deps);
+
+    const finalPatch = deps.executionPatches[deps.executionPatches.length - 1];
+    expect(finalPatch?.patch.status).toBe("failed");
+  });
+
+  test("部分 Investigation 失敗 + Integration 成功 → execution_completed を発行する", async () => {
+    let callCount = 0;
+    const partialStream = (
+      input: LlmInput,
+      signal?: AbortSignal,
+    ): AsyncIterable<string> => {
+      if (input.system.includes("調査")) {
+        callCount++;
+        // 1回目は失敗、2回目以降は成功
+        if (callCount === 1) return makeStream(["invalid json"])(input, signal);
+        return investigationStream(input, signal);
+      }
+      return integrationStream(input, signal);
+    };
+
+    const deps = makeFakeDeps(partialStream);
+    await runExecution(baseInput, deps);
+
+    const completedEvent = deps.events.find(
+      (e) => e.kind === "execution_completed",
+    );
+    expect(completedEvent).toBeDefined();
+    expect(deps.insertedResults).toHaveLength(1);
+  });
+
+  test("Integration 失敗 → execution_failed('integration_failed') を発行する", async () => {
+    const mixedStream = (
+      input: LlmInput,
+      signal?: AbortSignal,
+    ): AsyncIterable<string> => {
+      if (input.system.includes("調査"))
+        return investigationStream(input, signal);
+      // Integration は無効出力（パース失敗）
+      return makeStream(["no matrix here"])(input, signal);
+    };
+
+    const deps = makeFakeDeps(mixedStream);
+    await runExecution(baseInput, deps);
+
+    const failEvent = deps.events.find((e) => e.kind === "execution_failed");
+    expect(failEvent).toBeDefined();
+    if (failEvent?.kind === "execution_failed") {
+      expect(failEvent.reason).toBe("integration_failed");
+    }
+
+    expect(deps.insertedResults).toHaveLength(0);
+  });
+
+  test("Execution 開始時に Execution.status が running に更新される", async () => {
+    const deps = makeFakeDeps();
+    await runExecution(baseInput, deps);
+
+    const firstPatch = deps.executionPatches[0];
+    expect(firstPatch?.patch.status).toBe("running");
+    expect(firstPatch?.id).toBe("exec-1");
+  });
+
+  test("エージェント単位タイムアウト → agent_failed('timeout') が発行される", async () => {
+    // 1ms タイムアウトで即座に中断される stream を用意
+    const slowStream = (
+      _input: LlmInput,
+      signal?: AbortSignal,
+    ): AsyncIterable<string> => {
+      async function* gen() {
+        await new Promise<void>((resolve, reject) => {
+          const id = setTimeout(resolve, 5000);
+          signal?.addEventListener("abort", () => {
+            clearTimeout(id);
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+        yield "never reached";
+      }
+      return gen();
+    };
+
+    const deps = makeFakeDeps(slowStream, { agentTimeoutMs: 1 });
+    await runExecution(baseInput, deps);
+
+    const timeoutEvent = deps.events.find(
+      (e) => e.kind === "agent_failed" && e.reason === "timeout",
+    );
+    expect(timeoutEvent).toBeDefined();
+  });
+
+  test("Execution 全体タイムアウト → execution_failed('timeout') が発行される", async () => {
+    const slowStream = (
+      _input: LlmInput,
+      signal?: AbortSignal,
+    ): AsyncIterable<string> => {
+      async function* gen() {
+        await new Promise<void>((resolve, reject) => {
+          const id = setTimeout(resolve, 5000);
+          signal?.addEventListener("abort", () => {
+            clearTimeout(id);
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+        yield "never reached";
+      }
+      return gen();
+    };
+
+    // execution タイムアウトは agent タイムアウトより短く設定
+    const deps = makeFakeDeps(slowStream, {
+      agentTimeoutMs: 5000,
+      executionTimeoutMs: 1,
+    });
+    await runExecution(baseInput, deps);
+
+    const failEvent = deps.events.find((e) => e.kind === "execution_failed");
+    expect(failEvent).toBeDefined();
+    if (failEvent?.kind === "execution_failed") {
+      expect(failEvent.reason).toBe("timeout");
+    }
+  });
+});

--- a/packages/agent-core/src/engine.test.ts
+++ b/packages/agent-core/src/engine.test.ts
@@ -169,10 +169,10 @@ function makeFakeDeps(
     input: LlmInput,
     signal?: AbortSignal,
   ): AsyncIterable<string> => {
-    // system プロンプトの内容で agent 種別を判定
-    if (input.system.includes("調査"))
-      return investigationStream(input, signal);
-    return integrationStream(input, signal);
+    // integration は investigation_results が JSON 展開されるため "findings" キーを含む
+    if (input.system.includes('"findings"'))
+      return integrationStream(input, signal);
+    return investigationStream(input, signal);
   };
 
   return {

--- a/packages/agent-core/src/engine.ts
+++ b/packages/agent-core/src/engine.ts
@@ -273,17 +273,29 @@ async function _runExecution(
 
   // ---------- Result INSERT → execution_completed ----------
 
-  const resultId = await deps.insertResult({
-    executionId,
-    markdown: integrationResult.markdown,
-    structured: integrationResult.output,
-  });
+  try {
+    const resultId = await deps.insertResult({
+      executionId,
+      markdown: integrationResult.markdown,
+      structured: integrationResult.output,
+    });
 
-  await deps.updateExecution(executionId, {
-    status: "completed",
-    completedAt: new Date(),
-  });
-  deps.onEvent({ kind: "execution_completed", resultId });
+    await deps.updateExecution(executionId, {
+      status: "completed",
+      completedAt: new Date(),
+    });
+    deps.onEvent({ kind: "execution_completed", resultId });
+  } catch (e) {
+    await deps
+      .updateExecution(executionId, {
+        status: "failed",
+        errorMessage: "internal_error",
+        completedAt: new Date(),
+      })
+      .catch(() => {});
+    deps.onEvent({ kind: "execution_failed", reason: "internal_error" });
+    throw e;
+  }
 }
 
 type InvestigationRunResult =

--- a/packages/agent-core/src/engine.ts
+++ b/packages/agent-core/src/engine.ts
@@ -1,0 +1,347 @@
+/**
+ * Execution オーケストレーター。
+ *
+ * Investigation Agent を並列実行し、成功分を Integration Agent に渡して Result を生成する。
+ * 副作用はすべて EngineRunDeps 経由で注入するため、DB / LLM の実装に依存しない。
+ *
+ * SSoT: docs/design/agent-execution.md §6（状態確定フロー）§7（タイムアウト）
+ */
+
+import type {
+  AgentRole,
+  CompetitorAnalysisParameters,
+  CompetitorAnalysisResult,
+  ExecutionStatus,
+  IntegrationAgentDefinition,
+  InvestigationAgentDefinition,
+  InvestigationAgentOutput,
+  TemplateDefinition,
+} from "@agent-team-studio/shared";
+import type { AgentExecutionPatch } from "./agent.ts";
+import { runIntegrationAgent, runInvestigationAgent } from "./agent.ts";
+import { AGENT_TIMEOUT_MS, EXECUTION_TIMEOUT_MS } from "./constants.ts";
+import type { AgentEvent } from "./events.ts";
+import type { LlmInput } from "./llm-client.ts";
+
+// ---------- 公開型 ----------
+
+/** executions テーブルへの書き込みパッチ型。 */
+export type ExecutionUpdatePatch = {
+  status: ExecutionStatus;
+  errorMessage?: string | null;
+  startedAt?: Date | null;
+  completedAt?: Date | null;
+};
+
+/** Result INSERT の入力型。 */
+export type InsertResultInput = {
+  executionId: string;
+  markdown: string;
+  structured: CompetitorAnalysisResult;
+};
+
+/** engine.ts が必要とする外部依存の注入口。 */
+export type EngineRunDeps = {
+  updateExecution: (id: string, patch: ExecutionUpdatePatch) => Promise<void>;
+  updateAgentExecution: (
+    id: string,
+    patch: AgentExecutionPatch,
+  ) => Promise<void>;
+  insertResult: (input: InsertResultInput) => Promise<string>;
+  onEvent: (event: AgentEvent) => void;
+  /** テスト用: 注入された場合は streamAgentMessage の代わりに使う */
+  _stream?: (input: LlmInput, signal?: AbortSignal) => AsyncIterable<string>;
+  /** テスト用: エージェント単位タイムアウト ms（省略時は定数値を使用） */
+  agentTimeoutMs?: number;
+  /** テスト用: Execution 全体タイムアウト ms（省略時は定数値を使用） */
+  executionTimeoutMs?: number;
+};
+
+/** runExecution の入力。 */
+export type EngineRunInput = {
+  executionId: string;
+  parameters: CompetitorAnalysisParameters;
+  templateDefinition: TemplateDefinition;
+  agentExecutions: { id: string; agentId: string; role: AgentRole }[];
+};
+
+// ---------- 内部ヘルパー ----------
+
+function findDefinition(
+  templateDefinition: TemplateDefinition,
+  agentId: string,
+): InvestigationAgentDefinition | IntegrationAgentDefinition | undefined {
+  return templateDefinition.agents.find((a) => a.agent_id === agentId);
+}
+
+/**
+ * Promise.race 用のタイムアウト promise。
+ * resolve ではなく reject することで race の勝者を明確にする。
+ */
+function timeoutSignalPair(ms: number): {
+  signal: AbortSignal;
+  clear: () => void;
+} {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), ms);
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(id),
+  };
+}
+
+// ---------- メイン ----------
+
+/**
+ * Execution を実行する。
+ *
+ * Investigation → Integration の順で処理し、すべての副作用を deps 経由で行う。
+ * タイムアウトは AbortSignal で伝播する。
+ */
+export async function runExecution(
+  input: EngineRunInput,
+  deps: EngineRunDeps,
+): Promise<void> {
+  const streamFn =
+    deps._stream ?? (await import("./llm-client.ts")).streamAgentMessage;
+  const agentTimeoutMs = deps.agentTimeoutMs ?? AGENT_TIMEOUT_MS;
+  const executionTimeoutMs = deps.executionTimeoutMs ?? EXECUTION_TIMEOUT_MS;
+
+  // Execution 全体タイムアウト用 AbortController
+  const execTimeout = timeoutSignalPair(executionTimeoutMs);
+
+  try {
+    await _runExecution(
+      input,
+      deps,
+      streamFn,
+      agentTimeoutMs,
+      execTimeout.signal,
+    );
+  } finally {
+    execTimeout.clear();
+  }
+}
+
+async function _runExecution(
+  input: EngineRunInput,
+  deps: EngineRunDeps,
+  streamFn: (input: LlmInput, signal?: AbortSignal) => AsyncIterable<string>,
+  agentTimeoutMs: number,
+  executionSignal: AbortSignal,
+): Promise<void> {
+  const { executionId, parameters, templateDefinition, agentExecutions } =
+    input;
+
+  // Execution を running に更新
+  await deps.updateExecution(executionId, {
+    status: "running",
+    startedAt: new Date(),
+  });
+
+  const investigationAes = agentExecutions.filter(
+    (ae) => ae.role === "investigation",
+  );
+  const integrationAes = agentExecutions.filter(
+    (ae) => ae.role === "integration",
+  );
+
+  // ---------- Investigation 並列実行 ----------
+
+  const investigationResults = await runInvestigationsWithTimeout(
+    investigationAes,
+    parameters,
+    templateDefinition,
+    deps,
+    streamFn,
+    agentTimeoutMs,
+    executionSignal,
+  );
+
+  // Execution タイムアウト確認
+  if (executionSignal.aborted) {
+    await deps.updateExecution(executionId, {
+      status: "failed",
+      errorMessage: "timeout",
+      completedAt: new Date(),
+    });
+    deps.onEvent({ kind: "execution_failed", reason: "timeout" });
+    return;
+  }
+
+  const successfulInvestigations = investigationResults.filter(
+    (
+      r,
+    ): r is {
+      success: true;
+      agentId: string;
+      output: InvestigationAgentOutput;
+    } => r.success === true,
+  );
+
+  if (successfulInvestigations.length === 0) {
+    await deps.updateExecution(executionId, {
+      status: "failed",
+      errorMessage: "all_investigations_failed",
+      completedAt: new Date(),
+    });
+    deps.onEvent({
+      kind: "execution_failed",
+      reason: "all_investigations_failed",
+    });
+    return;
+  }
+
+  // ---------- Integration 実行 ----------
+
+  const integrationAe = integrationAes[0];
+  if (!integrationAe) {
+    // Integration エージェントが定義されていない（設計上は必ず存在する）
+    await deps.updateExecution(executionId, {
+      status: "failed",
+      errorMessage: "integration_failed",
+      completedAt: new Date(),
+    });
+    deps.onEvent({ kind: "execution_failed", reason: "integration_failed" });
+    return;
+  }
+
+  const integrationDef = findDefinition(
+    templateDefinition,
+    integrationAe.agentId,
+  );
+  if (!integrationDef || integrationDef.role !== "integration") {
+    await deps.updateExecution(executionId, {
+      status: "failed",
+      errorMessage: "integration_failed",
+      completedAt: new Date(),
+    });
+    deps.onEvent({ kind: "execution_failed", reason: "integration_failed" });
+    return;
+  }
+
+  // Integration エージェント用 AbortController（agent タイムアウト）
+  const agentTimeout = timeoutSignalPair(agentTimeoutMs);
+  // Execution タイムアウトでも中断できるよう、両方を監視する合成 signal を作る
+  const combinedController = new AbortController();
+  const abortCombined = () => combinedController.abort();
+  executionSignal.addEventListener("abort", abortCombined);
+  agentTimeout.signal.addEventListener("abort", abortCombined);
+
+  const integrationResult = await runIntegrationAgent(
+    {
+      agentExecutionId: integrationAe.id,
+      agentId: integrationAe.agentId,
+      definition: integrationDef,
+      parameters,
+      successfulInvestigations,
+      llm: templateDefinition.llm,
+      signal: combinedController.signal,
+    },
+    {
+      stream: streamFn,
+      updateAgentExecution: deps.updateAgentExecution,
+      onEvent: deps.onEvent,
+    },
+  );
+
+  agentTimeout.clear();
+  executionSignal.removeEventListener("abort", abortCombined);
+  agentTimeout.signal.removeEventListener("abort", abortCombined);
+
+  if (executionSignal.aborted) {
+    await deps.updateExecution(executionId, {
+      status: "failed",
+      errorMessage: "timeout",
+      completedAt: new Date(),
+    });
+    deps.onEvent({ kind: "execution_failed", reason: "timeout" });
+    return;
+  }
+
+  if (!integrationResult.success) {
+    await deps.updateExecution(executionId, {
+      status: "failed",
+      errorMessage: "integration_failed",
+      completedAt: new Date(),
+    });
+    deps.onEvent({ kind: "execution_failed", reason: "integration_failed" });
+    return;
+  }
+
+  // ---------- Result INSERT → execution_completed ----------
+
+  const resultId = await deps.insertResult({
+    executionId,
+    markdown: integrationResult.markdown,
+    structured: integrationResult.output as CompetitorAnalysisResult,
+  });
+
+  await deps.updateExecution(executionId, {
+    status: "completed",
+    completedAt: new Date(),
+  });
+  deps.onEvent({ kind: "execution_completed", resultId });
+}
+
+type InvestigationRunResult =
+  | { success: true; agentId: string; output: InvestigationAgentOutput }
+  | { success: false };
+
+async function runInvestigationsWithTimeout(
+  agentExecutions: { id: string; agentId: string; role: AgentRole }[],
+  parameters: CompetitorAnalysisParameters,
+  templateDefinition: TemplateDefinition,
+  deps: EngineRunDeps,
+  streamFn: (input: LlmInput, signal?: AbortSignal) => AsyncIterable<string>,
+  agentTimeoutMs: number,
+  executionSignal: AbortSignal,
+): Promise<InvestigationRunResult[]> {
+  const results = await Promise.allSettled(
+    agentExecutions.map(async (ae) => {
+      const def = findDefinition(templateDefinition, ae.agentId);
+      if (!def || def.role !== "investigation") {
+        return { success: false } as InvestigationRunResult;
+      }
+
+      const agentTimeout = timeoutSignalPair(agentTimeoutMs);
+      const combinedController = new AbortController();
+      const abortCombined = () => combinedController.abort();
+      executionSignal.addEventListener("abort", abortCombined);
+      agentTimeout.signal.addEventListener("abort", abortCombined);
+
+      const result = await runInvestigationAgent(
+        {
+          agentExecutionId: ae.id,
+          agentId: ae.agentId,
+          definition: def,
+          parameters,
+          llm: templateDefinition.llm,
+          signal: combinedController.signal,
+        },
+        {
+          stream: streamFn,
+          updateAgentExecution: deps.updateAgentExecution,
+          onEvent: deps.onEvent,
+        },
+      );
+
+      agentTimeout.clear();
+      executionSignal.removeEventListener("abort", abortCombined);
+      agentTimeout.signal.removeEventListener("abort", abortCombined);
+
+      if (result.success) {
+        return {
+          success: true,
+          agentId: ae.agentId,
+          output: result.output,
+        } as InvestigationRunResult;
+      }
+      return { success: false } as InvestigationRunResult;
+    }),
+  );
+
+  return results.map((r) =>
+    r.status === "fulfilled" ? r.value : { success: false },
+  );
+}

--- a/packages/agent-core/src/engine.ts
+++ b/packages/agent-core/src/engine.ts
@@ -222,32 +222,34 @@ async function _runExecution(
 
   // Integration エージェント用 AbortController（agent タイムアウト）
   const agentTimeout = timeoutSignalPair(agentTimeoutMs);
-  // Execution タイムアウトでも中断できるよう、両方を監視する合成 signal を作る
   const combinedController = new AbortController();
   const abortCombined = () => combinedController.abort();
   executionSignal.addEventListener("abort", abortCombined);
   agentTimeout.signal.addEventListener("abort", abortCombined);
 
-  const integrationResult = await runIntegrationAgent(
-    {
-      agentExecutionId: integrationAe.id,
-      agentId: integrationAe.agentId,
-      definition: integrationDef,
-      parameters,
-      successfulInvestigations,
-      llm: templateDefinition.llm,
-      signal: combinedController.signal,
-    },
-    {
-      stream: streamFn,
-      updateAgentExecution: deps.updateAgentExecution,
-      onEvent: deps.onEvent,
-    },
-  );
-
-  agentTimeout.clear();
-  executionSignal.removeEventListener("abort", abortCombined);
-  agentTimeout.signal.removeEventListener("abort", abortCombined);
+  let integrationResult: Awaited<ReturnType<typeof runIntegrationAgent>>;
+  try {
+    integrationResult = await runIntegrationAgent(
+      {
+        agentExecutionId: integrationAe.id,
+        agentId: integrationAe.agentId,
+        definition: integrationDef,
+        parameters,
+        successfulInvestigations,
+        llm: templateDefinition.llm,
+        signal: combinedController.signal,
+      },
+      {
+        stream: streamFn,
+        updateAgentExecution: deps.updateAgentExecution,
+        onEvent: deps.onEvent,
+      },
+    );
+  } finally {
+    agentTimeout.clear();
+    executionSignal.removeEventListener("abort", abortCombined);
+    agentTimeout.signal.removeEventListener("abort", abortCombined);
+  }
 
   if (executionSignal.aborted) {
     await deps.updateExecution(executionId, {
@@ -274,7 +276,7 @@ async function _runExecution(
   const resultId = await deps.insertResult({
     executionId,
     markdown: integrationResult.markdown,
-    structured: integrationResult.output as CompetitorAnalysisResult,
+    structured: integrationResult.output,
   });
 
   await deps.updateExecution(executionId, {
@@ -310,25 +312,28 @@ async function runInvestigationsWithTimeout(
       executionSignal.addEventListener("abort", abortCombined);
       agentTimeout.signal.addEventListener("abort", abortCombined);
 
-      const result = await runInvestigationAgent(
-        {
-          agentExecutionId: ae.id,
-          agentId: ae.agentId,
-          definition: def,
-          parameters,
-          llm: templateDefinition.llm,
-          signal: combinedController.signal,
-        },
-        {
-          stream: streamFn,
-          updateAgentExecution: deps.updateAgentExecution,
-          onEvent: deps.onEvent,
-        },
-      );
-
-      agentTimeout.clear();
-      executionSignal.removeEventListener("abort", abortCombined);
-      agentTimeout.signal.removeEventListener("abort", abortCombined);
+      let result: Awaited<ReturnType<typeof runInvestigationAgent>>;
+      try {
+        result = await runInvestigationAgent(
+          {
+            agentExecutionId: ae.id,
+            agentId: ae.agentId,
+            definition: def,
+            parameters,
+            llm: templateDefinition.llm,
+            signal: combinedController.signal,
+          },
+          {
+            stream: streamFn,
+            updateAgentExecution: deps.updateAgentExecution,
+            onEvent: deps.onEvent,
+          },
+        );
+      } finally {
+        agentTimeout.clear();
+        executionSignal.removeEventListener("abort", abortCombined);
+        agentTimeout.signal.removeEventListener("abort", abortCombined);
+      }
 
       if (result.success) {
         return {

--- a/packages/agent-core/src/events.ts
+++ b/packages/agent-core/src/events.ts
@@ -1,0 +1,25 @@
+/**
+ * agent-core 内部の進捗イベント型定義。
+ *
+ * SSoT: docs/design/agent-execution.md §5（実装後は本ファイルが SSoT）
+ * engine が発行し、apps/api がコールバック経由で受け取って WsMessage に写像する。
+ */
+
+import type {
+  AgentFailReason,
+  ExecutionFailReason,
+} from "@agent-team-studio/shared";
+
+/** engine → apps/api への進捗通知イベント。discriminated union で `kind` により識別する。 */
+export type AgentEvent =
+  | { kind: "agent_started"; agentId: string; startedAt: string }
+  | { kind: "agent_output_chunk"; agentId: string; chunk: string }
+  | { kind: "agent_completed"; agentId: string; completedAt: string }
+  | {
+      kind: "agent_failed";
+      agentId: string;
+      reason: AgentFailReason;
+      failedAt: string;
+    }
+  | { kind: "execution_completed"; resultId: string }
+  | { kind: "execution_failed"; reason: ExecutionFailReason };

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -7,4 +7,5 @@ export type {
 export { runExecution } from "./engine.ts";
 export type { AgentEvent } from "./events.ts";
 export type { LlmInput } from "./llm-client.ts";
-export { LlmError, streamAgentMessage } from "./llm-client.ts";
+export { streamAgentMessage } from "./llm-client.ts";
+export { LlmError } from "./llm-error.ts";

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -1,2 +1,10 @@
+export type {
+  EngineRunDeps,
+  EngineRunInput,
+  ExecutionUpdatePatch,
+  InsertResultInput,
+} from "./engine.ts";
+export { runExecution } from "./engine.ts";
+export type { AgentEvent } from "./events.ts";
 export type { LlmInput } from "./llm-client.ts";
 export { LlmError, streamAgentMessage } from "./llm-client.ts";

--- a/packages/agent-core/src/llm-client.test.ts
+++ b/packages/agent-core/src/llm-client.test.ts
@@ -252,7 +252,7 @@ describe("streamAgentMessage", () => {
   });
 });
 
-// capturedClientOptions はモジュールロード時（dynamic import）に1回だけ記録される
+// capturedClientOptions は streamAgentMessage の初回呼び出し時（= getClient() 初回実行時）に記録される
 describe("クライアント初期化", () => {
   test("maxRetries=3 / timeout=120000 で初期化されている", () => {
     expect(capturedClientOptions).toMatchObject({

--- a/packages/agent-core/src/llm-client.test.ts
+++ b/packages/agent-core/src/llm-client.test.ts
@@ -39,7 +39,8 @@ mock.module("@anthropic-ai/sdk", () => {
 });
 
 // SDK モック確立後にモジュールを dynamic import
-const { LlmError, streamAgentMessage } = await import("./llm-client.ts");
+const { streamAgentMessage } = await import("./llm-client.ts");
+const { LlmError } = await import("./llm-error.ts");
 
 // ---- ヘルパー ----
 

--- a/packages/agent-core/src/llm-client.ts
+++ b/packages/agent-core/src/llm-client.ts
@@ -1,8 +1,9 @@
 /**
  * Anthropic SDK の薄いラッパー。
  *
- * クライアントは初回呼び出し時に初期化する（lazy singleton）。
- * `LLM_API_KEY` 未設定の場合は `streamAgentMessage` の呼び出し時に throw する。
+ * クライアントは lazy singleton で初回呼び出し時に初期化する。
+ * モジュールロード時に副作用がないため、fake stream を DI するテストで
+ * `LLM_API_KEY` 不要かつ `mock.module` が正しく適用される。
  * エラーは `LlmError` に統一し、AbortSignal による中断はそのまま伝播する。
  */
 

--- a/packages/agent-core/src/llm-client.ts
+++ b/packages/agent-core/src/llm-client.ts
@@ -1,14 +1,12 @@
 /**
  * Anthropic SDK の薄いラッパー。
  *
- * クライアントは lazy singleton で初回呼び出し時に初期化する。
- * モジュールロード時に副作用がないため、fake stream を DI するテストで
- * `LLM_API_KEY` 不要かつ `mock.module` が正しく適用される。
+ * モジュールロード時に `LLM_API_KEY` を検証する副作用がある。
  * エラーは `LlmError` に統一し、AbortSignal による中断はそのまま伝播する。
  */
 
-import type { AgentFailReason } from "@agent-team-studio/shared";
 import Anthropic from "@anthropic-ai/sdk";
+import { LlmError } from "./llm-error.ts";
 
 /** LLM 呼び出しのパラメータ（モデル・プロンプト・温度・トークン上限）。 */
 export type LlmInput = {
@@ -19,39 +17,22 @@ export type LlmInput = {
   max_tokens: number;
 };
 
-/** LLM API 失敗を表すカスタムエラー。`failReason` で失敗の種別を識別する。 */
-export class LlmError extends Error {
-  readonly failReason: AgentFailReason;
-
-  constructor(
-    failReason: AgentFailReason,
-    message: string,
-    options?: ErrorOptions,
-  ) {
-    super(message, options);
-    this.name = "LlmError";
-    this.failReason = failReason;
-  }
+const apiKey = process.env.LLM_API_KEY;
+if (!apiKey) {
+  throw new Error("LLM_API_KEY is not set");
 }
 
-let _client: Anthropic | null = null;
+const clientOptions: ConstructorParameters<typeof Anthropic>[0] = {
+  apiKey,
+  maxRetries: 3,
+  timeout: 120_000,
+};
 
-/** 初回呼び出し時にクライアントを生成してキャッシュする。 */
-function getClient(): Anthropic {
-  if (_client) return _client;
-  const apiKey = process.env.LLM_API_KEY;
-  if (!apiKey) throw new Error("LLM_API_KEY is not set");
-  const options: ConstructorParameters<typeof Anthropic>[0] = {
-    apiKey,
-    maxRetries: 3,
-    timeout: 120_000,
-  };
-  if (process.env.LLM_BASE_URL) {
-    options.baseURL = process.env.LLM_BASE_URL;
-  }
-  _client = new Anthropic(options);
-  return _client;
+if (process.env.LLM_BASE_URL) {
+  clientOptions.baseURL = process.env.LLM_BASE_URL;
 }
+
+const client = new Anthropic(clientOptions);
 
 /**
  * LLM からのテキストを非同期ストリームで返す。
@@ -63,7 +44,6 @@ export async function* streamAgentMessage(
   input: LlmInput,
   signal?: AbortSignal,
 ): AsyncIterable<string> {
-  const client = getClient();
   try {
     const stream = client.messages.stream(
       {

--- a/packages/agent-core/src/llm-client.ts
+++ b/packages/agent-core/src/llm-client.ts
@@ -1,7 +1,8 @@
 /**
  * Anthropic SDK の薄いラッパー。
  *
- * モジュールロード時に `LLM_API_KEY` を検証する副作用がある。
+ * クライアントは初回呼び出し時に初期化する（lazy singleton）。
+ * `LLM_API_KEY` 未設定の場合は `streamAgentMessage` の呼び出し時に throw する。
  * エラーは `LlmError` に統一し、AbortSignal による中断はそのまま伝播する。
  */
 
@@ -32,22 +33,24 @@ export class LlmError extends Error {
   }
 }
 
-const apiKey = process.env.LLM_API_KEY;
-if (!apiKey) {
-  throw new Error("LLM_API_KEY is not set");
+let _client: Anthropic | null = null;
+
+/** 初回呼び出し時にクライアントを生成してキャッシュする。 */
+function getClient(): Anthropic {
+  if (_client) return _client;
+  const apiKey = process.env.LLM_API_KEY;
+  if (!apiKey) throw new Error("LLM_API_KEY is not set");
+  const options: ConstructorParameters<typeof Anthropic>[0] = {
+    apiKey,
+    maxRetries: 3,
+    timeout: 120_000,
+  };
+  if (process.env.LLM_BASE_URL) {
+    options.baseURL = process.env.LLM_BASE_URL;
+  }
+  _client = new Anthropic(options);
+  return _client;
 }
-
-const clientOptions: ConstructorParameters<typeof Anthropic>[0] = {
-  apiKey,
-  maxRetries: 3,
-  timeout: 120_000,
-};
-
-if (process.env.LLM_BASE_URL) {
-  clientOptions.baseURL = process.env.LLM_BASE_URL;
-}
-
-const client = new Anthropic(clientOptions);
 
 /**
  * LLM からのテキストを非同期ストリームで返す。
@@ -59,6 +62,7 @@ export async function* streamAgentMessage(
   input: LlmInput,
   signal?: AbortSignal,
 ): AsyncIterable<string> {
+  const client = getClient();
   try {
     const stream = client.messages.stream(
       {

--- a/packages/agent-core/src/llm-error.ts
+++ b/packages/agent-core/src/llm-error.ts
@@ -1,0 +1,16 @@
+import type { AgentFailReason } from "@agent-team-studio/shared";
+
+/** LLM API 失敗を表すカスタムエラー。`failReason` で失敗の種別を識別する。 */
+export class LlmError extends Error {
+  readonly failReason: AgentFailReason;
+
+  constructor(
+    failReason: AgentFailReason,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "LlmError";
+    this.failReason = failReason;
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7,6 +7,8 @@
  */
 
 export { createDbClient, type DbClient, type DrizzleDb } from "./client.ts";
+export * from "./repositories/agent-executions.ts";
 export * from "./repositories/executions.ts";
+export * from "./repositories/results.ts";
 export * from "./repositories/templates.ts";
 export * as schema from "./schema/index.ts";

--- a/packages/db/src/repositories/agent-executions.ts
+++ b/packages/db/src/repositories/agent-executions.ts
@@ -1,0 +1,46 @@
+/**
+ * AgentExecution の更新リポジトリ。
+ *
+ * エンジンから「DB UPDATE → イベント発行」の順序で呼び出される。
+ * 呼び出し元はこの関数の完了を待ってからイベントを発行すること。
+ */
+
+import type {
+  AgentStatus,
+  IntegrationAgentOutput,
+  InvestigationAgentOutput,
+} from "@agent-team-studio/shared";
+import { eq } from "drizzle-orm";
+import type { DrizzleDb } from "../client.ts";
+import { agentExecutions } from "../schema/index.ts";
+
+/** `agent_executions` テーブルの可変フィールドのパッチ型。 */
+export type AgentExecutionUpdatePatch = {
+  status: AgentStatus;
+  output?: InvestigationAgentOutput | IntegrationAgentOutput;
+  errorMessage?: string | null;
+  startedAt?: Date | null;
+  completedAt?: Date | null;
+};
+
+/** AgentExecution のステータス・出力を更新する。 */
+export async function updateAgentExecution(
+  db: DrizzleDb,
+  id: string,
+  patch: AgentExecutionUpdatePatch,
+): Promise<void> {
+  await db
+    .update(agentExecutions)
+    .set({
+      status: patch.status,
+      ...(patch.output !== undefined && { output: patch.output }),
+      ...(patch.errorMessage !== undefined && {
+        errorMessage: patch.errorMessage,
+      }),
+      ...(patch.startedAt !== undefined && { startedAt: patch.startedAt }),
+      ...(patch.completedAt !== undefined && {
+        completedAt: patch.completedAt,
+      }),
+    })
+    .where(eq(agentExecutions.id, id));
+}

--- a/packages/db/src/repositories/executions.ts
+++ b/packages/db/src/repositories/executions.ts
@@ -8,8 +8,10 @@ import type {
   AgentRole,
   CompetitorAnalysisParameters,
   CreateExecutionResponse,
+  ExecutionStatus,
   TemplateId,
 } from "@agent-team-studio/shared";
+import { eq } from "drizzle-orm";
 import type { DrizzleDb } from "../client.ts";
 import { agentExecutions, executions } from "../schema/index.ts";
 
@@ -60,4 +62,38 @@ export async function createExecution(
       createdAt: execution.createdAt.toISOString(),
     };
   });
+}
+
+/** `executions` テーブルの可変フィールドのパッチ型。 */
+export type ExecutionUpdatePatch = {
+  status: ExecutionStatus;
+  errorMessage?: string | null;
+  startedAt?: Date | null;
+  completedAt?: Date | null;
+};
+
+/**
+ * Execution のステータスを更新する。
+ *
+ * エンジンから呼び出される副作用。「DB UPDATE → イベント発行」の順序を保証するため、
+ * 呼び出し元（engine）は本関数の完了を待ってからイベントを発行すること。
+ */
+export async function updateExecution(
+  db: DrizzleDb,
+  id: string,
+  patch: ExecutionUpdatePatch,
+): Promise<void> {
+  await db
+    .update(executions)
+    .set({
+      status: patch.status,
+      ...(patch.errorMessage !== undefined && {
+        errorMessage: patch.errorMessage,
+      }),
+      ...(patch.startedAt !== undefined && { startedAt: patch.startedAt }),
+      ...(patch.completedAt !== undefined && {
+        completedAt: patch.completedAt,
+      }),
+    })
+    .where(eq(executions.id, id));
 }

--- a/packages/db/src/repositories/results.ts
+++ b/packages/db/src/repositories/results.ts
@@ -1,0 +1,38 @@
+/**
+ * Result の INSERT リポジトリ。
+ *
+ * Integration Agent 完了後にエンジンから呼び出される。
+ * Execution との 1:0..1 制約は DB の UNIQUE 制約で施行する（data-model.md §3）。
+ */
+
+import type { CompetitorAnalysisResult } from "@agent-team-studio/shared";
+import type { DrizzleDb } from "../client.ts";
+import { results } from "../schema/index.ts";
+
+/** `insertResult` の入力型。 */
+export type InsertResultInput = {
+  executionId: string;
+  markdown: string;
+  structured: CompetitorAnalysisResult;
+};
+
+/**
+ * Result を INSERT し、生成された ID を返す。
+ *
+ * エンジンは返された resultId を `execution_completed` イベントに含める。
+ */
+export async function insertResult(
+  db: DrizzleDb,
+  input: InsertResultInput,
+): Promise<string> {
+  const [result] = await db
+    .insert(results)
+    .values({
+      executionId: input.executionId,
+      markdown: input.markdown,
+      structured: input.structured,
+    })
+    .returning({ id: results.id });
+  if (!result) throw new Error("failed to insert result");
+  return result.id;
+}

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -63,6 +63,7 @@ export const EXECUTION_FAIL_REASONS = [
   "all_investigations_failed",
   "integration_failed",
   "timeout",
+  "internal_error",
 ] as const;
 
 export type AgentFailReason = (typeof AGENT_FAIL_REASONS)[number];


### PR DESCRIPTION
## Summary

- Investigation / Integration Agent の実装（`agent.ts`）
- 並列実行・状態確定・タイムアウトを担う Engine の実装（`engine.ts`）
- DB リポジトリの追加（`updateExecution` / `updateAgentExecution` / `insertResult`）
- `llm-client.ts` の依存分離リファクタリング（`LlmError` を `llm-error.ts` に分離）

## 変更内容

### 新規ファイル（`packages/agent-core/src/`）

| ファイル | 内容 |
|---|---|
| `events.ts` | `AgentEvent` discriminated union（SSoT） |
| `constants.ts` | タイムアウト定数（agent: 300s, execution: 1500s） |
| `agent.ts` | `runInvestigationAgent` / `runIntegrationAgent` |
| `agent.test.ts` | 13テスト |
| `engine.ts` | `runExecution`（並列 Investigation → Integration → Result INSERT） |
| `engine.test.ts` | 10テスト |
| `llm-error.ts` | `LlmError` の独立ファイル |

### 修正ファイル

- `packages/agent-core/src/index.ts` — 公開 API export 追加
- `packages/agent-core/src/llm-client.ts` — `LlmError` を `llm-error.ts` から import
- `packages/db/src/repositories/executions.ts` — `updateExecution` 追加
- `packages/db/src/repositories/agent-executions.ts` — 新規（`updateAgentExecution`）
- `packages/db/src/repositories/results.ts` — 新規（`insertResult`）
- `packages/db/src/index.ts` — 新規 repo を export

### 設計上のポイント

- **DB 副作用順序**: 「DB UPDATE → イベント発行」を各エージェントで保証
- **並列実行**: `Promise.allSettled` で Investigation を並列実行（障害隔離）
- **タイムアウト**: エージェント単位（300s）と Execution 全体（1500s）を AbortSignal で制御
- **依存分離**: `LlmError` を `llm-error.ts` に分離し `agent.ts` → `llm-client.ts` の依存を除去。`mock.module` が正しく適用されテストの信頼性が向上

### スコープ外（次 Issue）

`runExecution` は実装済みだが、API（`apps/api`）からの呼び出しは未接続。画面からの動作確認は次 Issue で対応。

## Test plan

- [x] `bun run test` — agent-core 31/31 pass
- [x] `bun run lint` — 全パッケージ pass
- [x] `bun run type-check` — 全パッケージ pass
- [x] `bun run build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)