### PR TITLE
fix(ci): Dependabot PR でレビューワークフローをスキップ

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   review:
-    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   review:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## What

`review.yml` の `if` 条件に `github.actor != 'dependabot[bot]'` を追加し、Dependabot PR でレビュージョブをスキップするようにした。

## Why

Dependabot PR では GitHub Actions がリポジトリシークレットにアクセスできない仕様のため、`CLAUDE_CODE_OAUTH_TOKEN` が空になりレビュージョブが常に失敗していた。

Dependabot のアップデートはコードレビューではなく自動マージ（`dependabot-auto-merge.yml`）で対応するため、レビューはスキップが適切。

## Checklist

- [ ] テストが通ること（該当する場合）
- [ ] ドキュメントを更新したこと（該当する場合）

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5FZUnskTZxNNM9UkmnoGQ)_