### PR TITLE
chore(ci): Dependabot patch PR を自動 Approve する

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,4 +18,6 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## What

`dependabot-auto-merge.yml` に auto-approve ステップを追加する。semver-patch の Dependabot PR に対して、auto-merge の前に `github-actions[bot]` で Approve を実行する。

## Why

ブランチ保護ルールセットの `require_code_owner_review` を削除したことで `github-actions[bot]` の Approve がマージ要件を満たすようになった。これにより Dependabot の patch 更新を完全自動化できる。

## Checklist

- [ ] テストが通ること（該当する場合）
- [ ] ドキュメントを更新したこと（該当する場合）