### PR TITLE
chore(project): .env ファイルを Claude Code の deny ルールで保護

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,6 +35,9 @@
       "Bash(git stash:*)",
       "Bash(git status:*)",
       "Bash(git switch:*)",
+      "Bash(git worktree add:*)",
+      "Bash(git worktree list:*)",
+      "Bash(git worktree remove:*)",
       "Bash(grep:*)",
       "Bash(gh issue comment:*)",
       "Bash(gh issue create:*)",
@@ -52,6 +55,8 @@
       "Bash(npm info:*)"
     ],
     "deny": [
+      "Read(**/.env)",
+      "Read(**/.env.local)",
       "Bash(rm -rf *)",
       "Bash(git push --force:*)",
       "Bash(git reset --hard:*)",


### PR DESCRIPTION
## What

`.claude/settings.json` の `permissions.deny` に `.env` と `.env.local` への Read を拒否するルールを追加した。

## Why

Claude Code は `.env` ファイルを読み取り Anthropic サーバーへ送信するリスクがある。`.claudeignore` ではバイパスされる事例が報告されており、`permissions.deny` が唯一確実な対策。

## Checklist

- [ ] テストが通ること（該当する場合）
- [ ] ドキュメントを更新したこと（該当する場合）