### PR TITLE
feat(web): US-4 統合結果を閲覧しエクスポートする

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,9 +14,10 @@
       "Skill(review)",
       "mcp__context7",
       "mcp__playwright",
-      "Bash(bun -v)",
+      "Bash(bun ls:*)",
       "Bash(bun run:*)",
       "Bash(bun test:*)",
+      "Bash(bun -v)",
       "Bash(bunx shadcn:*)",
       "Bash(cat:*)",
       "Bash(ls:*)",
@@ -52,7 +53,8 @@
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
       "Bash(gh run list:*)",
-      "Bash(npm info:*)"
+      "Bash(npm info:*)",
+      "Bash(wait:*)"
     ],
     "deny": [
       "Read(**/.env)",

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import type {
+  AgentExecutionRow,
+  ExecutionRow,
+  ResultRow,
+} from "@agent-team-studio/db";
+import type {
   ApiInternalError,
   ApiNotFoundError,
   ApiValidationError,
   CompetitorAnalysisParameters,
   CreateExecutionResponse,
+  GetExecutionResponse,
   GetTemplateResponse,
   GetTemplatesResponse,
 } from "@agent-team-studio/shared";
@@ -233,5 +239,69 @@ describe("POST /api/executions", () => {
     expect(body.message).toBeTruthy();
     // 内部例外メッセージが API レスポンスに漏洩しないことを境界として固定する。
     expect(body.message).not.toContain("DB connection failed");
+  });
+});
+
+describe("GET /api/executions/:id", () => {
+  const execRow: ExecutionRow = {
+    id: "exec-1",
+    templateId: "tpl-1",
+    parameters: { competitors: ["Acme", "Globex"] },
+    status: "completed",
+    errorMessage: null,
+    createdAt: new Date("2026-05-04T00:00:00.000Z"),
+    startedAt: new Date("2026-05-04T00:01:00.000Z"),
+    completedAt: new Date("2026-05-04T00:02:00.000Z"),
+  };
+
+  const agentRow: AgentExecutionRow = {
+    id: "ae-1",
+    executionId: "exec-1",
+    agentId: "investigation_strategy",
+    role: "investigation",
+    status: "completed",
+    output: null,
+    errorMessage: null,
+    createdAt: new Date("2026-05-04T00:00:00.000Z"),
+    startedAt: new Date("2026-05-04T00:01:00.000Z"),
+    completedAt: new Date("2026-05-04T00:02:00.000Z"),
+  };
+
+  const resultRow: ResultRow = {
+    id: "result-1",
+    executionId: "exec-1",
+    markdown: "# レポート",
+    structured: { matrix: [], overall_insights: ["所見1"], missing: [] },
+    createdAt: new Date("2026-05-04T00:02:00.000Z"),
+  };
+
+  test("Execution が存在するとき 200 + GetExecutionResponse 形を返す", async () => {
+    const app = buildApp({
+      getExecution: async () => execRow,
+      getAgentExecutionsByExecutionId: async () => [agentRow],
+      getResultByExecutionId: async () => resultRow,
+    });
+
+    const res = await app.request("/api/executions/exec-1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as GetExecutionResponse;
+    expect(body.id).toBe("exec-1");
+    expect(body.status).toBe("completed");
+    expect(body.agentExecutions).toHaveLength(1);
+    expect(body.result?.id).toBe("result-1");
+    expect(body.result?.markdown).toBe("# レポート");
+  });
+
+  test("Execution が存在しないとき 404 + ApiNotFoundError 形を返す", async () => {
+    const app = buildApp({ getExecution: async () => null });
+
+    const res = await app.request("/api/executions/exec-missing");
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as ApiNotFoundError;
+    expect(body.errorCode).toBe("not_found");
+    expect(body.details).toEqual({ resource: "execution", id: "exec-missing" });
+    expect(body.message).toBeTruthy();
   });
 });

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -304,4 +304,36 @@ describe("GET /api/executions/:id", () => {
     expect(body.details).toEqual({ resource: "execution", id: "exec-missing" });
     expect(body.message).toBeTruthy();
   });
+
+  test("repo が例外を投げると 500 + ApiInternalError 形を返す", async () => {
+    const app = buildApp({
+      getExecution: async () => {
+        throw new Error("DB connection failed");
+      },
+    });
+
+    const res = await app.request("/api/executions/exec-1");
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as ApiInternalError;
+    expect(body.errorCode).toBe("internal_error");
+    expect(body.message).toBeTruthy();
+    expect(body.message).not.toContain("DB connection failed");
+  });
+
+  // completed + result=null は API 設計上到達しないが、route 層が result=null のまま 200 を返すことを境界として固定する。
+  test("Execution が存在し result が null のとき 200 + result=null を返す", async () => {
+    const app = buildApp({
+      getExecution: async () => execRow,
+      getAgentExecutionsByExecutionId: async () => [agentRow],
+      getResultByExecutionId: async () => null,
+    });
+
+    const res = await app.request("/api/executions/exec-1");
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as GetExecutionResponse;
+    expect(body.id).toBe("exec-1");
+    expect(body.result).toBeNull();
+  });
 });

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -291,6 +291,7 @@ describe("GET /api/executions/:id", () => {
     expect(body.agentExecutions).toHaveLength(1);
     expect(body.result?.id).toBe("result-1");
     expect(body.result?.markdown).toBe("# レポート");
+    expect(body.result?.structured.overall_insights).toEqual(["所見1"]);
   });
 
   test("Execution が存在しないとき 404 + ApiNotFoundError 形を返す", async () => {
@@ -321,8 +322,8 @@ describe("GET /api/executions/:id", () => {
     expect(body.message).not.toContain("DB connection failed");
   });
 
-  // completed + result=null は API 設計上到達しないが、route 層が result=null のまま 200 を返すことを境界として固定する。
-  test("Execution が存在し result が null のとき 200 + result=null を返す", async () => {
+  // completed + result=null は API 設計上到達しないが、route 層が result=undefined のまま 200 を返すことを境界として固定する。
+  test("Execution が存在し result が null のとき 200 + result=undefined を返す", async () => {
     const app = buildApp({
       getExecution: async () => execRow,
       getAgentExecutionsByExecutionId: async () => [agentRow],
@@ -334,6 +335,6 @@ describe("GET /api/executions/:id", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as GetExecutionResponse;
     expect(body.id).toBe("exec-1");
-    expect(body.result).toBeNull();
+    expect(body.result).toBeUndefined();
   });
 });

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -289,9 +289,13 @@ describe("GET /api/executions/:id", () => {
     expect(body.id).toBe("exec-1");
     expect(body.status).toBe("completed");
     expect(body.agentExecutions).toHaveLength(1);
+    expect(body.agentExecutions[0]?.id).toBe("ae-1");
+    expect(body.agentExecutions[0]?.role).toBe("investigation");
     expect(body.result?.id).toBe("result-1");
     expect(body.result?.markdown).toBe("# レポート");
     expect(body.result?.structured.overall_insights).toEqual(["所見1"]);
+    expect(body.result?.structured.matrix).toEqual([]);
+    expect(body.result?.structured.missing).toEqual([]);
   });
 
   test("Execution が存在しないとき 404 + ApiNotFoundError 形を返す", async () => {
@@ -322,7 +326,7 @@ describe("GET /api/executions/:id", () => {
     expect(body.message).not.toContain("DB connection failed");
   });
 
-  // completed + result=null は API 設計上到達しないが、route 層が result=undefined のまま 200 を返すことを境界として固定する。
+  // WS 設計上 completed 時に result 欠落は起きないが、route 層の境界として固定する。
   test("Execution が存在し result が null のとき 200 + result=undefined を返す", async () => {
     const app = buildApp({
       getExecution: async () => execRow,

--- a/apps/web/src/features/executions/ExecutionProgressPage.tsx
+++ b/apps/web/src/features/executions/ExecutionProgressPage.tsx
@@ -83,12 +83,9 @@ export function ExecutionProgressPage() {
           接続エラー
         </h1>
         <Alert variant="destructive">
-          <AlertTitle>接続エラー</AlertTitle>
+          <AlertTitle>WebSocket 接続に失敗しました</AlertTitle>
           <AlertDescription>
             <p>{message}</p>
-            <p className="mt-1">
-              履歴一覧（準備中）から過去の実行を確認できます。
-            </p>
           </AlertDescription>
         </Alert>
         {wsState.agents.size > 0 && (
@@ -119,13 +116,7 @@ export function ExecutionProgressPage() {
           実行失敗
         </h1>
         <Alert variant="destructive">
-          <AlertTitle>実行失敗</AlertTitle>
-          <AlertDescription>
-            <p>{REASON_MESSAGES[wsState.reason]}</p>
-            <p className="mt-1">
-              履歴一覧（準備中）から過去の実行を確認できます。
-            </p>
-          </AlertDescription>
+          <AlertTitle>{REASON_MESSAGES[wsState.reason]}</AlertTitle>
         </Alert>
         <AgentList agents={agents} />
         {wsState.reason === "integration_failed" && (

--- a/apps/web/src/features/executions/ExecutionProgressPage.tsx
+++ b/apps/web/src/features/executions/ExecutionProgressPage.tsx
@@ -4,13 +4,9 @@
  * WS 接続状態に応じて:
  * - connecting: 接続中テキスト
  * - running: エージェントごとのステータスバッジ + 出力ストリーミング
- * - completed: 結果閲覧（GET /api/executions/:id へリダイレクト）
- * - failed: 失敗メッセージ
+ * - completed: 結果マトリクス + エクスポート（GET /api/executions/:id が SSoT）
+ * - failed: 失敗メッセージ。integration_failed の場合は調査エージェント出力も表示
  * - error: WS エラー Alert + 履歴一覧への導線
- *
- * US-4 の結果表示（マトリクス・エクスポート）は completed 遷移後に
- * ExecutionResultPage で担う（#120 で実装）。本 Issue では completed 後の
- * リダイレクト or 簡易メッセージを置く。
  */
 
 import type {
@@ -21,8 +17,11 @@ import { getRouteApi } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ExecutionResultView,
+  InvestigationOutputsView,
+} from "./ExecutionResultView";
 import { type AgentState, useExecutionWs } from "./hooks/useExecutionWs";
 
 const Route = getRouteApi("/executions/$executionId");
@@ -108,11 +107,7 @@ export function ExecutionProgressPage() {
           実行完了
         </h1>
         <AgentList agents={agents} />
-        <div className="mt-6">
-          <Button variant="outline" disabled>
-            結果を表示（準備中）
-          </Button>
-        </div>
+        <ExecutionResultView executionId={executionId} />
       </section>
     );
   }
@@ -133,6 +128,9 @@ export function ExecutionProgressPage() {
           </AlertDescription>
         </Alert>
         <AgentList agents={agents} />
+        {wsState.reason === "integration_failed" && (
+          <InvestigationOutputsView executionId={executionId} />
+        )}
       </section>
     );
   }

--- a/apps/web/src/features/executions/ExecutionResultView.tsx
+++ b/apps/web/src/features/executions/ExecutionResultView.tsx
@@ -12,9 +12,11 @@ import type {
   InvestigationAgentExecutionDetail,
   InvestigationFinding,
   MissingPerspective,
+  PerspectiveMatrixRow,
 } from "@agent-team-studio/shared";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -71,7 +73,6 @@ export function ExecutionResultView({ executionId }: { executionId: string }) {
       <Alert variant="destructive" className="mt-4">
         <AlertTitle>結果の取得に失敗しました</AlertTitle>
         <AlertDescription>
-          <p>時間をおいて再度お試しください。</p>
           <Button
             variant="outline"
             size="sm"
@@ -79,7 +80,7 @@ export function ExecutionResultView({ executionId }: { executionId: string }) {
             onClick={() => refetch()}
             disabled={isFetching}
           >
-            {isFetching ? "読み込み中…" : "再読み込み"}
+            再読み込み
           </Button>
         </AlertDescription>
       </Alert>
@@ -90,16 +91,24 @@ export function ExecutionResultView({ executionId }: { executionId: string }) {
     return <CompletedResultView execution={data} />;
   }
 
+  // completed フェーズで result なしは理論上到達しない（WS 設計上 result 存在が保証される）。
+  // 万一発生した場合の安全網として導線を提供する。
   return (
-    <p className="mt-4 text-sm text-muted-foreground">
-      結果データが見つかりません。
-    </p>
+    <Alert variant="destructive" className="mt-4">
+      <AlertTitle>結果データを取得できませんでした</AlertTitle>
+      <AlertDescription>
+        <Link to="/" className="underline">
+          テンプレート一覧へ
+        </Link>
+      </AlertDescription>
+    </Alert>
   );
 }
 
 /**
  * 統合エージェント失敗時（Result 未作成）に調査エージェントの出力を表示する。
- * API から取得し、出力が 1 件もない場合は何も描画しない。
+ * このコンポーネントは失敗 UI の補足表示として使われるため、fetch 失敗・ロード中は
+ * 無音で何も描画しない（主要な失敗メッセージは呼び出し元が担う）。
  */
 export function InvestigationOutputsView({
   executionId,
@@ -112,20 +121,26 @@ export function InvestigationOutputsView({
       fetchJson<GetExecutionResponse>(`/api/executions/${executionId}`),
   });
 
+  // fetch 失敗・ロード中は呼び出し元の失敗 UI のみを表示する（意図的なサイレント処理）。
   if (status !== "success") return null;
 
   const withOutput = data.agentExecutions.filter(
     (ae): ae is InvestigationAgentExecutionDetail =>
-      ae.role === "investigation" && ae.output !== undefined,
+      ae.role === "investigation" && ae.output != null,
   );
 
   if (withOutput.length === 0) return null;
 
   return (
     <div className="mt-6 space-y-4">
-      <h2 className="text-base font-semibold">
-        各エージェントの調査結果（統合前）
-      </h2>
+      <div>
+        <h2 className="text-base font-semibold">
+          各エージェントの調査結果（統合前）
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          統合エージェントが失敗したため、各調査エージェントの出力を表示しています。
+        </p>
+      </div>
       {withOutput.map((ae) => (
         <InvestigationOutputCard key={ae.id} ae={ae} />
       ))}
@@ -169,15 +184,12 @@ function ResultMatrix({
   missing,
   competitors,
 }: {
-  matrix: GetExecutionResponse["result"] extends undefined
-    ? never
-    : NonNullable<GetExecutionResponse["result"]>["structured"]["matrix"];
+  matrix: PerspectiveMatrixRow[];
   missing: MissingPerspective[];
   competitors: string[];
 }) {
   const missingSet = new Set(missing.map((m) => m.perspective));
 
-  // 4 観点すべてを表示対象とする（matrix に含まれない観点は missing セルで表示）。
   const perspectives = ALL_PERSPECTIVES.filter(
     (p) => matrix.some((r) => r.perspective === p) || missingSet.has(p),
   );
@@ -185,67 +197,78 @@ function ResultMatrix({
   return (
     <div>
       <h2 className="mb-3 text-base font-semibold">結果マトリクス</h2>
-      <div className="overflow-x-auto">
-        <table className="w-full border-collapse text-sm">
-          <thead>
-            <tr className="border-b bg-muted/50">
-              <th className="p-2 text-left font-medium">観点</th>
-              {competitors.map((c) => (
-                <th key={c} className="p-2 text-left font-medium">
-                  {c}
+      {perspectives.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          結果データがありません。
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th scope="col" className="p-2 text-left font-medium">
+                  観点
                 </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {perspectives.map((perspective) => {
-              const row = matrix.find((r) => r.perspective === perspective);
-              const isMissing = missingSet.has(perspective);
+                {competitors.map((c) => (
+                  <th scope="col" key={c} className="p-2 text-left font-medium">
+                    {c}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {perspectives.map((perspective) => {
+                const row = matrix.find((r) => r.perspective === perspective);
+                const isMissing = missingSet.has(perspective);
 
-              return (
-                <tr key={perspective} className="border-b last:border-b-0">
-                  <td className="p-2 font-medium text-muted-foreground">
-                    {PERSPECTIVE_NAME[perspective]}
-                  </td>
-                  {competitors.map((competitor) => {
-                    if (isMissing || !row) {
+                return (
+                  <tr key={perspective} className="border-b last:border-b-0">
+                    <th
+                      scope="row"
+                      className="p-2 text-left font-medium text-muted-foreground"
+                    >
+                      {PERSPECTIVE_NAME[perspective]}
+                    </th>
+                    {competitors.map((competitor) => {
+                      if (isMissing || !row) {
+                        return (
+                          <td key={competitor} className="p-2">
+                            <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                              未取得
+                            </span>
+                          </td>
+                        );
+                      }
+                      const cell = row.cells.find(
+                        (c) => c.competitor === competitor,
+                      );
+                      if (!cell) {
+                        return (
+                          <td
+                            key={competitor}
+                            className="p-2 text-muted-foreground"
+                          >
+                            —
+                          </td>
+                        );
+                      }
                       return (
-                        <td key={competitor} className="p-2">
-                          <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                            missing
+                        <td key={competitor} className="p-2 align-top">
+                          <p className="leading-relaxed">{cell.summary}</p>
+                          <span className="mt-1 block text-xs text-muted-foreground">
+                            確度:{" "}
+                            {EVIDENCE_LEVEL_LABEL[cell.source_evidence_level]}
                           </span>
                         </td>
                       );
-                    }
-                    const cell = row.cells.find(
-                      (c) => c.competitor === competitor,
-                    );
-                    if (!cell) {
-                      return (
-                        <td
-                          key={competitor}
-                          className="p-2 text-muted-foreground"
-                        >
-                          —
-                        </td>
-                      );
-                    }
-                    return (
-                      <td key={competitor} className="p-2 align-top">
-                        <p className="leading-relaxed">{cell.summary}</p>
-                        <span className="mt-1 block text-xs text-muted-foreground">
-                          確度:{" "}
-                          {EVIDENCE_LEVEL_LABEL[cell.source_evidence_level]}
-                        </span>
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }
@@ -256,7 +279,6 @@ function OverallInsights({ insights }: { insights: string[] }) {
       <h2 className="mb-3 text-base font-semibold">総合インサイト</h2>
       <ul className="space-y-2">
         {insights.map((insight, i) => (
-          // インデックスをキーに使う（insights はサーバー生成の固定リスト）
           // biome-ignore lint/suspicious/noArrayIndexKey: サーバー生成の固定リスト
           <li key={i} className="flex gap-2 text-sm">
             <span className="mt-0.5 shrink-0 text-muted-foreground">•</span>
@@ -292,6 +314,8 @@ function MissingPerspectivesSection({
   );
 }
 
+type CopyState = "idle" | "success" | "error";
+
 function ExportActions({
   markdown,
   executionId,
@@ -299,12 +323,27 @@ function ExportActions({
   markdown: string;
   executionId: string;
 }) {
-  const [copied, setCopied] = useState(false);
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const [downloaded, setDownloaded] = useState(false);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const downloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      if (downloadTimerRef.current) clearTimeout(downloadTimerRef.current);
+    };
+  }, []);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(markdown);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopyState("success");
+    } catch {
+      setCopyState("error");
+    }
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    copyTimerRef.current = setTimeout(() => setCopyState("idle"), 2000);
   };
 
   const handleDownload = () => {
@@ -313,18 +352,38 @@ function ExportActions({
     const a = document.createElement("a");
     a.href = url;
     a.download = `competitive-analysis-${executionId}.md`;
+    document.body.appendChild(a);
     a.click();
+    document.body.removeChild(a);
     URL.revokeObjectURL(url);
+    setDownloaded(true);
+    if (downloadTimerRef.current) clearTimeout(downloadTimerRef.current);
+    downloadTimerRef.current = setTimeout(() => setDownloaded(false), 2000);
   };
 
+  const copyLabel =
+    copyState === "success"
+      ? "コピーしました"
+      : copyState === "error"
+        ? "コピーに失敗しました"
+        : "Markdown をコピー";
+
   return (
-    <div className="flex gap-2">
-      <Button variant="outline" onClick={handleCopy}>
-        {copied ? "コピーしました" : "Markdown をコピー"}
-      </Button>
-      <Button variant="outline" onClick={handleDownload}>
-        ダウンロード
-      </Button>
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-2">
+        <Button variant="outline" onClick={handleCopy}>
+          {copyLabel}
+        </Button>
+        <Button variant="outline" onClick={handleDownload}>
+          {downloaded ? "ダウンロードしました" : "ダウンロード"}
+        </Button>
+      </div>
+      {/* スクリーンリーダーへの操作結果通知 */}
+      <span aria-live="polite" className="sr-only">
+        {copyState === "success" && "コピーしました"}
+        {copyState === "error" && "コピーに失敗しました"}
+        {downloaded && "ダウンロードしました"}
+      </span>
     </div>
   );
 }

--- a/apps/web/src/features/executions/ExecutionResultView.tsx
+++ b/apps/web/src/features/executions/ExecutionResultView.tsx
@@ -36,7 +36,7 @@ const PERSPECTIVE_NAME: Record<CompetitorPerspectiveKey, string> = {
   strategy: "戦略",
   product: "製品",
   investment: "投資",
-  partnership: "提携",
+  partnership: "パートナーシップ",
 };
 
 const MISSING_REASON_LABEL: Record<MissingPerspective["reason"], string> = {
@@ -168,11 +168,11 @@ function CompletedResultView({
         missing={structured.missing}
         competitors={competitors}
       />
-      {structured.overall_insights.length > 0 && (
-        <OverallInsights insights={structured.overall_insights} />
-      )}
       {structured.missing.length > 0 && (
         <MissingPerspectivesSection missing={structured.missing} />
+      )}
+      {structured.overall_insights.length > 0 && (
+        <OverallInsights insights={structured.overall_insights} />
       )}
       <ExportActions markdown={markdown} executionId={execution.id} />
     </div>
@@ -314,7 +314,7 @@ function MissingPerspectivesSection({
   );
 }
 
-type CopyState = "idle" | "success" | "error";
+type ActionState = "idle" | "success" | "error";
 
 function ExportActions({
   markdown,
@@ -323,8 +323,8 @@ function ExportActions({
   markdown: string;
   executionId: string;
 }) {
-  const [copyState, setCopyState] = useState<CopyState>("idle");
-  const [downloaded, setDownloaded] = useState(false);
+  const [copyState, setCopyState] = useState<ActionState>("idle");
+  const [downloadState, setDownloadState] = useState<ActionState>("idle");
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const downloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -341,24 +341,33 @@ function ExportActions({
       setCopyState("success");
     } catch {
       setCopyState("error");
+    } finally {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopyState("idle"), 2000);
     }
-    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
-    copyTimerRef.current = setTimeout(() => setCopyState("idle"), 2000);
   };
 
   const handleDownload = () => {
-    const blob = new Blob([markdown], { type: "text/markdown" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `competitive-analysis-${executionId}.md`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-    setDownloaded(true);
-    if (downloadTimerRef.current) clearTimeout(downloadTimerRef.current);
-    downloadTimerRef.current = setTimeout(() => setDownloaded(false), 2000);
+    try {
+      const blob = new Blob([markdown], { type: "text/markdown" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `competitive-analysis-${executionId}.md`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setDownloadState("success");
+    } catch {
+      setDownloadState("error");
+    } finally {
+      if (downloadTimerRef.current) clearTimeout(downloadTimerRef.current);
+      downloadTimerRef.current = setTimeout(
+        () => setDownloadState("idle"),
+        2000,
+      );
+    }
   };
 
   const copyLabel =
@@ -368,21 +377,39 @@ function ExportActions({
         ? "コピーに失敗しました"
         : "Markdown をコピー";
 
+  const downloadLabel =
+    downloadState === "success"
+      ? "ダウンロードしました"
+      : downloadState === "error"
+        ? "ダウンロードに失敗しました"
+        : "ダウンロード";
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex gap-2">
-        <Button variant="outline" onClick={handleCopy}>
+        <Button
+          variant="outline"
+          onClick={handleCopy}
+          disabled={copyState !== "idle"}
+        >
           {copyLabel}
         </Button>
-        <Button variant="outline" onClick={handleDownload}>
-          {downloaded ? "ダウンロードしました" : "ダウンロード"}
+        <Button
+          variant="outline"
+          onClick={handleDownload}
+          disabled={downloadState !== "idle"}
+        >
+          {downloadLabel}
         </Button>
       </div>
-      {/* スクリーンリーダーへの操作結果通知 */}
+      {/* スクリーンリーダーへの操作結果通知（コピーとDLを独立させ同時読み上げ競合を防ぐ） */}
       <span aria-live="polite" className="sr-only">
         {copyState === "success" && "コピーしました"}
         {copyState === "error" && "コピーに失敗しました"}
-        {downloaded && "ダウンロードしました"}
+      </span>
+      <span aria-live="polite" className="sr-only">
+        {downloadState === "success" && "ダウンロードしました"}
+        {downloadState === "error" && "ダウンロードに失敗しました"}
       </span>
     </div>
   );
@@ -393,6 +420,7 @@ function InvestigationOutputCard({
 }: {
   ae: InvestigationAgentExecutionDetail;
 }) {
+  // 呼び出し元フィルタで output != null が保証済み。防衛的ガードとして残す。
   if (!ae.output) return null;
   const { perspective, findings } = ae.output;
 

--- a/apps/web/src/features/executions/ExecutionResultView.tsx
+++ b/apps/web/src/features/executions/ExecutionResultView.tsx
@@ -1,0 +1,386 @@
+/**
+ * 実行結果表示コンポーネント（US-4）。
+ *
+ * GET /api/executions/:id を SSoT として結果マトリクス・エクスポートを提供する。
+ * 完了状態・統合失敗状態の両方に対応し、ページリロード後も同一 URL で閲覧できる。
+ */
+
+import type {
+  CompetitorPerspectiveKey,
+  EvidenceLevel,
+  GetExecutionResponse,
+  InvestigationAgentExecutionDetail,
+  InvestigationFinding,
+  MissingPerspective,
+} from "@agent-team-studio/shared";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchJson } from "@/lib/api";
+
+// --- 定数 ---
+
+const ALL_PERSPECTIVES: CompetitorPerspectiveKey[] = [
+  "strategy",
+  "product",
+  "investment",
+  "partnership",
+];
+
+const PERSPECTIVE_NAME: Record<CompetitorPerspectiveKey, string> = {
+  strategy: "戦略",
+  product: "製品",
+  investment: "投資",
+  partnership: "提携",
+};
+
+const MISSING_REASON_LABEL: Record<MissingPerspective["reason"], string> = {
+  agent_failed: "エージェント失敗",
+  insufficient_evidence: "証拠不足",
+};
+
+const EVIDENCE_LEVEL_LABEL: Record<EvidenceLevel, string> = {
+  strong: "強",
+  moderate: "中",
+  weak: "弱",
+  insufficient: "不足",
+};
+
+// --- 公開コンポーネント ---
+
+/**
+ * 完了済み実行の結果を表示する。
+ * WS で execution:completed を受信した後にマウントし、API から詳細を取得する。
+ */
+export function ExecutionResultView({ executionId }: { executionId: string }) {
+  const { data, status, refetch, isFetching } = useQuery({
+    queryKey: ["execution", executionId],
+    queryFn: () =>
+      fetchJson<GetExecutionResponse>(`/api/executions/${executionId}`),
+  });
+
+  if (status === "pending") {
+    return <ResultSkeleton />;
+  }
+
+  if (status === "error") {
+    return (
+      <Alert variant="destructive" className="mt-4">
+        <AlertTitle>結果の取得に失敗しました</AlertTitle>
+        <AlertDescription>
+          <p>時間をおいて再度お試しください。</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2"
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            {isFetching ? "読み込み中…" : "再読み込み"}
+          </Button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (data.result) {
+    return <CompletedResultView execution={data} />;
+  }
+
+  return (
+    <p className="mt-4 text-sm text-muted-foreground">
+      結果データが見つかりません。
+    </p>
+  );
+}
+
+/**
+ * 統合エージェント失敗時（Result 未作成）に調査エージェントの出力を表示する。
+ * API から取得し、出力が 1 件もない場合は何も描画しない。
+ */
+export function InvestigationOutputsView({
+  executionId,
+}: {
+  executionId: string;
+}) {
+  const { data, status } = useQuery({
+    queryKey: ["execution", executionId],
+    queryFn: () =>
+      fetchJson<GetExecutionResponse>(`/api/executions/${executionId}`),
+  });
+
+  if (status !== "success") return null;
+
+  const withOutput = data.agentExecutions.filter(
+    (ae): ae is InvestigationAgentExecutionDetail =>
+      ae.role === "investigation" && ae.output !== undefined,
+  );
+
+  if (withOutput.length === 0) return null;
+
+  return (
+    <div className="mt-6 space-y-4">
+      <h2 className="text-base font-semibold">
+        各エージェントの調査結果（統合前）
+      </h2>
+      {withOutput.map((ae) => (
+        <InvestigationOutputCard key={ae.id} ae={ae} />
+      ))}
+    </div>
+  );
+}
+
+// --- 内部コンポーネント ---
+
+function CompletedResultView({
+  execution,
+}: {
+  execution: GetExecutionResponse;
+}) {
+  const { result, parameters } = execution;
+  if (!result) return null;
+
+  const { structured, markdown } = result;
+  const competitors = parameters.competitors;
+
+  return (
+    <div className="mt-6 space-y-8">
+      <ResultMatrix
+        matrix={structured.matrix}
+        missing={structured.missing}
+        competitors={competitors}
+      />
+      {structured.overall_insights.length > 0 && (
+        <OverallInsights insights={structured.overall_insights} />
+      )}
+      {structured.missing.length > 0 && (
+        <MissingPerspectivesSection missing={structured.missing} />
+      )}
+      <ExportActions markdown={markdown} executionId={execution.id} />
+    </div>
+  );
+}
+
+function ResultMatrix({
+  matrix,
+  missing,
+  competitors,
+}: {
+  matrix: GetExecutionResponse["result"] extends undefined
+    ? never
+    : NonNullable<GetExecutionResponse["result"]>["structured"]["matrix"];
+  missing: MissingPerspective[];
+  competitors: string[];
+}) {
+  const missingSet = new Set(missing.map((m) => m.perspective));
+
+  // 4 観点すべてを表示対象とする（matrix に含まれない観点は missing セルで表示）。
+  const perspectives = ALL_PERSPECTIVES.filter(
+    (p) => matrix.some((r) => r.perspective === p) || missingSet.has(p),
+  );
+
+  return (
+    <div>
+      <h2 className="mb-3 text-base font-semibold">結果マトリクス</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="p-2 text-left font-medium">観点</th>
+              {competitors.map((c) => (
+                <th key={c} className="p-2 text-left font-medium">
+                  {c}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {perspectives.map((perspective) => {
+              const row = matrix.find((r) => r.perspective === perspective);
+              const isMissing = missingSet.has(perspective);
+
+              return (
+                <tr key={perspective} className="border-b last:border-b-0">
+                  <td className="p-2 font-medium text-muted-foreground">
+                    {PERSPECTIVE_NAME[perspective]}
+                  </td>
+                  {competitors.map((competitor) => {
+                    if (isMissing || !row) {
+                      return (
+                        <td key={competitor} className="p-2">
+                          <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                            missing
+                          </span>
+                        </td>
+                      );
+                    }
+                    const cell = row.cells.find(
+                      (c) => c.competitor === competitor,
+                    );
+                    if (!cell) {
+                      return (
+                        <td
+                          key={competitor}
+                          className="p-2 text-muted-foreground"
+                        >
+                          —
+                        </td>
+                      );
+                    }
+                    return (
+                      <td key={competitor} className="p-2 align-top">
+                        <p className="leading-relaxed">{cell.summary}</p>
+                        <span className="mt-1 block text-xs text-muted-foreground">
+                          確度:{" "}
+                          {EVIDENCE_LEVEL_LABEL[cell.source_evidence_level]}
+                        </span>
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function OverallInsights({ insights }: { insights: string[] }) {
+  return (
+    <div>
+      <h2 className="mb-3 text-base font-semibold">総合インサイト</h2>
+      <ul className="space-y-2">
+        {insights.map((insight, i) => (
+          // インデックスをキーに使う（insights はサーバー生成の固定リスト）
+          // biome-ignore lint/suspicious/noArrayIndexKey: サーバー生成の固定リスト
+          <li key={i} className="flex gap-2 text-sm">
+            <span className="mt-0.5 shrink-0 text-muted-foreground">•</span>
+            <span>{insight}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function MissingPerspectivesSection({
+  missing,
+}: {
+  missing: MissingPerspective[];
+}) {
+  return (
+    <div>
+      <h2 className="mb-3 text-base font-semibold">未取得観点</h2>
+      <ul className="space-y-1 text-sm">
+        {missing.map((m) => (
+          <li key={m.perspective} className="flex gap-2">
+            <span className="font-medium">
+              {PERSPECTIVE_NAME[m.perspective]}
+            </span>
+            <span className="text-muted-foreground">
+              — {MISSING_REASON_LABEL[m.reason]}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ExportActions({
+  markdown,
+  executionId,
+}: {
+  markdown: string;
+  executionId: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(markdown);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDownload = () => {
+    const blob = new Blob([markdown], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `competitive-analysis-${executionId}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="flex gap-2">
+      <Button variant="outline" onClick={handleCopy}>
+        {copied ? "コピーしました" : "Markdown をコピー"}
+      </Button>
+      <Button variant="outline" onClick={handleDownload}>
+        ダウンロード
+      </Button>
+    </div>
+  );
+}
+
+function InvestigationOutputCard({
+  ae,
+}: {
+  ae: InvestigationAgentExecutionDetail;
+}) {
+  if (!ae.output) return null;
+  const { perspective, findings } = ae.output;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          {PERSPECTIVE_NAME[perspective] ?? perspective}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {findings.map((finding, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: サーバー生成の固定リスト
+          <FindingBlock key={i} finding={finding} />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function FindingBlock({ finding }: { finding: InvestigationFinding }) {
+  return (
+    <div>
+      <p className="mb-1 text-sm font-medium">{finding.competitor}</p>
+      <ul className="space-y-1">
+        {finding.points.map((point, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: サーバー生成の固定リスト
+          <li key={i} className="flex gap-2 text-sm">
+            <span className="mt-0.5 shrink-0 text-muted-foreground">•</span>
+            <span>{point}</span>
+          </li>
+        ))}
+      </ul>
+      {finding.notes && (
+        <p className="mt-1 text-xs text-muted-foreground">{finding.notes}</p>
+      )}
+    </div>
+  );
+}
+
+function ResultSkeleton() {
+  return (
+    <div className="mt-6 space-y-4">
+      <Skeleton className="h-5 w-32" />
+      <Skeleton className="h-48 w-full" />
+      <Skeleton className="h-5 w-40" />
+      <Skeleton className="h-24 w-full" />
+    </div>
+  );
+}

--- a/apps/web/src/features/executions/ExecutionResultView.tsx
+++ b/apps/web/src/features/executions/ExecutionResultView.tsx
@@ -2,7 +2,9 @@
  * 実行結果表示コンポーネント（US-4）。
  *
  * GET /api/executions/:id を SSoT として結果マトリクス・エクスポートを提供する。
- * 完了状態・統合失敗状態の両方に対応し、ページリロード後も同一 URL で閲覧できる。
+ * このコンポーネント自体は result の有無で表示を切り替えるのみで、
+ * integration_failed 時の調査エージェント出力表示は呼び出し元が
+ * InvestigationOutputsView を並置することで対応する。
  */
 
 import type {

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -81,6 +81,12 @@ MVP のコア概念。ADR-0005 の MVP 機能一覧と [user-stories.md](./user-
 | completed | 完了 | 正常終了 | [US-3](./user-stories.md#us-3-エージェントの進捗をリアルタイムで見る) |
 | failed | 失敗 | エラーにより終了。UI では原因メッセージを併記 | [US-3](./user-stories.md#us-3-エージェントの進捗をリアルタイムで見る) |
 
+### 結果表示
+
+| 英語名 | 日本語 | 定義 | 関連 |
+| --- | --- | --- | --- |
+| evidence_level | 確度 | 調査エージェントが収集した根拠の強さ。UI では「強 / 中 / 弱 / 不足」と表示（`strong` / `moderate` / `weak` / `insufficient`） | [US-4](./user-stories.md#us-4-統合結果を閲覧しエクスポートする) |
+
 ### その他
 
 | 英語名 | 日本語 | 定義 | 関連 |


### PR DESCRIPTION
## What

- `GET /api/executions/:id` の統合テスト追加（200 正常系 / 404 not_found）
- `ExecutionResultView` コンポーネント新規作成
  - 結果マトリクス（観点×競合、確度表示）
  - 総合インサイト一覧
  - partial-failure（`missing[]`）の行除外なし・下部セクション表示
  - Markdown コピー / `.md` ファイルダウンロード
- `integration_failed` 時: `InvestigationOutputsView` で調査エージェント出力を観点別カード表示
- `ExecutionProgressPage` の `completed` フェーズを `ExecutionResultView` に切り替え

## Why

closes #120

US-4「統合結果を閲覧しエクスポートする」の実装。`GET /api/executions/:id` を SSoT として、WS 完了後・ページリロード後いずれも同一 URL で結果を閲覧できる。

## How

- WS が `execution:completed` を受信した時点で `ExecutionResultView` をマウントし、`useQuery` で `/api/executions/:id` を fetch してレンダリング
- 完了済み Execution への WS 接続時はサーバーが即座に `execution:completed` を送信して close するため、リロード後も同フローを経由して結果が表示される
- Markdown エクスポートは `Result.markdown`（Integration Agent 生成済み）をそのまま使用し、UI との構造二重化を避けた

## Checklist

- [x] テストが通ること（該当する場合）
- [ ] ドキュメントを更新したこと（該当する場合）