### PR TITLE
chore(project): bunfig.toml で minimumReleaseAge=3日 を設定

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,6 +3,8 @@
 # 公開〜検知の時間差 (例: 2026-05-11 TanStack 侵害は約20分で検知) で
 # 悪意あるバージョンを踏むリスクを低減する。
 # Dependabot cooldown (semver-patch-days: 3) と整合した 3 日 = 259200 秒。
+# 有効な文脈: ローカル bun add / lockfile 更新時 (解決が走るタイミング)。
+# CI (--frozen-lockfile) は解決をスキップして lockfile 通り install するため不適用。
 minimumReleaseAge = 259200
 
 # 補足: Bun はデフォルトで依存パッケージのライフサイクルスクリプトを実行しない

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,12 @@
+[install]
+# npm に publish 直後の新しいバージョンを一定期間 install させない。
+# 公開〜検知の時間差 (例: 2026-05-11 TanStack 侵害は約20分で検知) で
+# 悪意あるバージョンを踏むリスクを低減する。
+# Dependabot cooldown (semver-patch-days: 3) と整合した 3 日 = 259200 秒。
+minimumReleaseAge = 259200
+
+# 補足: Bun はデフォルトで依存パッケージのライフサイクルスクリプトを実行しない
+# (postinstall 等は trustedDependencies で明示許可した分のみ走る) ため、
+# npm/pnpm でいう ignore-scripts = true 相当の防御は既に効いている。
+# ここで ignoreScripts = true を有効化するとプロジェクト自身の prepare
+# (husky セットアップ) も止まり pre-commit フックが機能しなくなるので設定しない。

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,9 +2,13 @@
 # npm に publish 直後の新しいバージョンを一定期間 install させない。
 # 公開〜検知の時間差 (例: 2026-05-11 TanStack 侵害は約20分で検知) で
 # 悪意あるバージョンを踏むリスクを低減する。
-# Dependabot cooldown (semver-patch-days: 3) と整合した 3 日 = 259200 秒。
+# Dependabot cooldown (semver-patch-days: 3) と数値を揃えた独立した防御層
+# (Dependabot 経路は cooldown が、ローカル経路は本設定がそれぞれ単独で遮断する) で、
+# 3 日 = 259200 秒。
 # 有効な文脈: ローカル bun add / lockfile 更新時 (解決が走るタイミング)。
 # CI (--frozen-lockfile) は解決をスキップして lockfile 通り install するため不適用。
+# 不適用ケース: registry を介さない直接 install (例: tarball / git / link 依存) は
+# publish 時刻を取得できないため本設定の対象外となる。
 minimumReleaseAge = 259200
 
 # 補足: Bun はデフォルトで依存パッケージのライフサイクルスクリプトを実行しない


### PR DESCRIPTION
## What

- `bunfig.toml` を新規作成し、`minimumReleaseAge = 259200`（3日間）を設定。

## Why

2026-05-11 に TanStack の 42 npm パッケージで発生したサプライチェーン攻撃（Mini Shai-Hulud / [GHSA-g7cv-rxg3-hmpx](https://github.com/TanStack/router/security/advisories/GHSA-g7cv-rxg3-hmpx)）を踏まえた防御強化。

公開〜検知の時間差（今回は約20分で検知）で悪意あるバージョンを install するリスクを、`bun install` レイヤで時間ベースに遮断する。Dependabot cooldown（`semver-patch-days: 3`）と整合させており、Dependabot 経路以外（開発者ローカルの `bun add` や手動 lockfile 更新）でも同等の時間稼ぎが効くようになる。

なお、本リポジトリの現状の依存（`bun.lock` 固定版）に悪意バージョン（`@tanstack/react-router` 1.169.5 / 1.169.8 等）は混入しておらず、CI は `bun install --frozen-lockfile` 運用のため CI 実行履歴にも問題は確認されなかった。本変更は将来の同種攻撃に対する defense-in-depth。

## How

- Bun 1.3 から利用可能な `[install].minimumReleaseAge`（秒）を採用
- `ignoreScripts = true` は採用しなかった理由を `bunfig.toml` のコメントで明示
  - Bun はデフォルトで依存パッケージのライフサイクルスクリプトを実行しない（`trustedDependencies` で明示許可分のみ）ため、`npm` / `pnpm` でいう同設定の追加防御は既に効いている
  - 一方で `ignoreScripts = true` はプロジェクト自身の `prepare`（husky セットアップ）も止めるため、pre-commit が機能しなくなる副作用を確認

## 検証

- `bun install --frozen-lockfile` で 1161 packages の install 成功
- husky の `prepare` が走り `.husky/_/` と `core.hooksPath` が再生成された
- pre-commit（secretlint / turbo lint / type-check）通過

## Checklist

- [x] テストが通ること（install / pre-commit 通過確認済み）
- [ ] ドキュメントを更新したこと（該当なし）


---
_Generated by [Claude Code](https://claude.ai/code/session_01LWV2ej8q8HBcKZ1fsg1NV9)_