### PR TITLE
feat(ci): Merge Queue 対応のため merge_group トリガーを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: "37 19 * * 2"
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -3,7 +3,6 @@ name: Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-  merge_group:
 
 permissions:
   contents: read
@@ -11,26 +10,20 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   review:
-    if: ${{ github.event_name == 'merge_group' || (!github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]') }}
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Skip review for merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Merge queue — review already performed on PR"
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: github.event_name == 'pull_request'
         with:
           fetch-depth: 1
 
       - name: Run Claude Code review
-        if: github.event_name == 'pull_request'
         uses: anthropics/claude-code-action@8c196b2f61a66bfdf93322bde3a3e668669089ed # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -3,6 +3,7 @@ name: Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+  merge_group:
 
 permissions:
   contents: read
@@ -10,20 +11,26 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
   cancel-in-progress: true
 
 jobs:
   review:
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ github.event_name == 'merge_group' || (!github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Skip review for merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Merge queue — review already performed on PR"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: github.event_name == 'pull_request'
         with:
           fetch-depth: 1
 
       - name: Run Claude Code review
+        if: github.event_name == 'pull_request'
         uses: anthropics/claude-code-action@8c196b2f61a66bfdf93322bde3a3e668669089ed # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## What

GitHub Merge Queue を有効化するための前提作業として、必須ステータスチェックを出している workflow に `merge_group` トリガーを追加する。

- `ci.yml` — lint / test / type-check
- `codeql.yml` — Analyze (actions) / Analyze (javascript-typescript) / CodeQL

`review.yml` は変更不要（マージ後に Ruleset から必須チェック登録を外すため）。

## Why

Dependabot PR 等で発生する **bun.lock 競合カスケード問題**を解消する。

- 現状: 複数 PR が並列 open → 1件マージするたび残り全件 conflict → 再リベース → CI 再実行を繰り返す
- 例: 10 件捌くのに延べ 55 回程度の CI 実行が必要
- 対策: Merge Queue で直列処理 → 延べ 20 回程度に削減

Merge Queue は merge_group イベントで queue 内 CI を実行する。必須ステータスチェックを出す workflow が `merge_group` トリガーを持っていないと、queue 内で必須チェックが報告されずマージが永久にブロックされるため、本 PR で先に対応する。

`review` チェックについては、失敗するのは Claude Code 実行エラー（インフラ問題）であり、コード品質ゲートではないため、必須チェックから外す方針とする（PR レビューは情報共有として workflow 自体は引き続き稼働）。

## How

- `ci.yml` / `codeql.yml`: トリガー一覧に `merge_group:` を追加
- このコミット単体では Merge Queue は有効化されない

## マージ後の手順

1. GitHub UI で Ruleset `branch-protection` を編集
2. **Required status checks** から `review` を削除
3. **Require merge queue** を有効化
4. 詰まっている Dependabot PR (#177, #178, #181) を close → Dependabot を再トリガー

## Checklist

- [ ] CI が pass すること
- [ ] マージ後に Ruleset から `review` を必須チェック外す
- [ ] マージ後に Ruleset で "Require merge queue" を有効化する
- [ ] 詰まっている Dependabot PR を close → 再生成