### PR TITLE
chore(project): MVP 受入確認 — max_tokens 調整と lint 除外設定 (#191)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -4,5 +4,5 @@
     "MD013": false
   },
   "globs": ["**/*.md"],
-  "ignores": ["**/node_modules", "_dev"]
+  "ignores": ["**/node_modules", "_dev", ".playwright-mcp"]
 }

--- a/docs/design/llm-integration.md
+++ b/docs/design/llm-integration.md
@@ -26,8 +26,8 @@ Claude API を用いた LLM 呼び出しの設計方針。`packages/agent-core/s
 
 | エージェント | temperature | max_tokens | 根拠 |
 | --- | --- | --- | --- |
-| Investigation Agent | 0.3 | 2,048 | 事実整理タスク。低 temperature で一貫性を確保。観点あたり競合 3〜5 件の JSON 出力に 2,048 で十分 |
-| Integration Agent | 0.2 | 4,096 | 矛盾抑制のためさらに低く設定。マトリクス Markdown + JSON の両方を出力するため 4,096 |
+| Investigation Agent | 0.3 | 1,500 | 事実整理タスク。低 temperature で一貫性を確保。観点あたり競合 3〜5 件の JSON 出力に 1,500 で十分 |
+| Integration Agent | 0.2 | 3,000 | 矛盾抑制のためさらに低く設定。マトリクス Markdown + JSON の両方を出力するため 3,000 |
 
 `top_p`, `top_k` はデフォルト値（未指定）とする。temperature で十分に制御できるため。
 
@@ -98,7 +98,7 @@ Hero UC（3 競合 × 4 観点）1 回の実行で想定されるトークン量
 | system prompt | ~500 | 役割定義 + 出力フォーマット指示 |
 | user message | ~3,000 | 競合リスト + 参考情報（最大 10,000 文字 ≒ 3,000 トークン） |
 | **入力合計** | **~3,500** | |
-| 出力（JSON） | ~800 | 競合 3 件 × 3〜5 ポイント（`max_tokens: 2048` で上限制御） |
+| 出力（JSON） | ~800 | 競合 3 件 × 3〜5 ポイント（`max_tokens: 1500` で上限制御） |
 | **入出力合計** | **~4,300** | |
 
 ### Integration Agent（1 エージェント）

--- a/packages/db/src/seed-data/competitor-analysis.ts
+++ b/packages/db/src/seed-data/competitor-analysis.ts
@@ -208,7 +208,7 @@ export const competitorAnalysisDefinition: TemplateDefinition = {
     // ここはシードデータへの転記値。SSoT を更新したら本ファイルも合わせて更新する。
     model: "claude-sonnet-4-6",
     temperature_by_role: { investigation: 0.3, integration: 0.2 },
-    max_tokens_by_role: { investigation: 2048, integration: 4096 },
+    max_tokens_by_role: { investigation: 1500, integration: 3000 },
   },
 };
 


### PR DESCRIPTION
## Summary

- v0.5 マイルストーン #116 の受入確認（#191）を実施
- OpenRouter 残高不足に対応するため `max_tokens_by_role` を調整（investigation: 2048→1500 / integration: 4096→3000）
- `.playwright-mcp/` を markdownlint 除外対象に追加

## 受入確認結果

| 条件 | 結果 |
|---|---|
| `bun run lint && bun run type-check && bun run test && bun run build` | ✅ 全緑 |
| 履歴一覧から過去実行が再閲覧できる | ✅ 確認済み |
| Hero UC 手動完遂（テンプレ選択→入力→実行→進捗→結果→エクスポート） | ✅ UI フロー確認済み（詳細は Issue コメント参照） |

詳細ログ・スクリーンショット証跡: #191

## Test plan

- [ ] CI（lint / type-check / test / build）グリーンを確認
- [ ] Issue #191 のコメントで受入ログを確認

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)