### PR TITLE
chore(ci): main への直接コミットを pre-commit で禁止

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,9 @@
+branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ "$branch" = "main" ]; then
+  echo "Error: main への直接コミットは禁止されています。ブランチを切ってください。"
+  exit 1
+fi
+
 # secretlint を必ず実行するため lint-staged を先頭に配置
 # 注意: markdownlint-cli2 はファイルパス直接渡しになるため .markdownlint-cli2.jsonc の ignores は機能しない
 #       （_dev は .gitignore 対象のためステージングされず実害なし）


### PR DESCRIPTION
## What

`.husky/pre-commit` に main ブランチへの直接コミットを禁止するチェックを追加。

## Why

main への誤コミットを防ぐためのガードレール。ブランチ戦略（GitHub Flow）の運用を強制する。

## How

軽微な変更のため省略

## Checklist

- [ ] テストが通ること（該当する場合）
- [ ] ドキュメントを更新したこと（該当する場合）