### PR TITLE
docs(guides): free-llm-setup.md を guides/README.md の一覧に追加 #195

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -15,3 +15,4 @@
 | [development-tools.md](./development-tools.md) | 開発ツール（psql / Drizzle Studio / PostgreSQL 拡張） |
 | [env.md](./env.md) | 環境変数・シークレット管理 |
 | [dependabot.md](./dependabot.md) | Dependabot 運用ガイド（PR 種別ごとの作業・auto-merge・cooldown） |
+| [free-llm-setup.md](./free-llm-setup.md) | LLM API 設定ガイド（Anthropic / OpenRouter / Ollama の切り替え） |


### PR DESCRIPTION
## What

`docs/guides/README.md` のガイド一覧に `free-llm-setup.md` を追加。

## Why

closes #195

参照リンク健全性レビュー（#195）の過程で、`docs/guides/free-llm-setup.md` が存在するにもかかわらず `docs/guides/README.md` の一覧表から漏れていることを発見したため修正。

## Checklist

- [ ] テストが通ること（該当する場合）
- [x] ドキュメントを更新したこと（該当する場合）