### PR TITLE
docs(guides): LLM プロバイダー切替時の max_tokens 制約を文書化 #212

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -10,13 +10,17 @@ LLM_API_KEY=YOUR_ANTHROPIC_API_KEY
 
 # --- Option B: OpenRouter（代替・無料） ---
 # https://openrouter.ai に登録して API キーを取得（無料モデル利用可）
-# 以下を有効化して使用（レート制限: 20 req/min, 50 req/day）
+# 以下を有効化して使用
+#   レート制限: 20 req/min, 50 req/day（$10 入金で 1000 req/day へ緩和）
+#   max_tokens: 個別リクエスト制限なし。モデルの Max Output に従う
+#               統合 Agent (max_tokens=8000) 要件を満たす無料モデルは
+#               docs/guides/free-llm-setup.md の「モデル別の max output tokens 上限」を参照
 # LLM_API_KEY=YOUR_OPENROUTER_API_KEY
 # LLM_BASE_URL=https://openrouter.ai/api
 # 無料モデルの場合は以下をいずれかに変更（コメント解除）
-# LLM_MODEL=llama-3.3-70b-specdec
-# LLM_MODEL=deepseek-r1
-# LLM_MODEL=qwen/qwen-coder-480b
+# LLM_MODEL=meta-llama/llama-3.3-70b-instruct:free
+# LLM_MODEL=deepseek/deepseek-r1:free
+# LLM_MODEL=qwen/qwen3-coder:free
 
 # --- Option C: Ollama（代替・ローカル無料） ---
 # Ollama をローカルで起動している場合に切り替え

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -9,18 +9,12 @@
 LLM_API_KEY=YOUR_ANTHROPIC_API_KEY
 
 # --- Option B: OpenRouter（代替・無料） ---
-# https://openrouter.ai に登録して API キーを取得（無料モデル利用可）
-# 以下を有効化して使用
-#   レート制限: 20 req/min, 50 req/day（$10 入金で 1,000 req/day へ緩和）
-#   max_tokens: 個別リクエスト制限なし。モデルの Max Output に従う
-#               統合 Agent (max_tokens=8000) 要件を満たす無料モデルは
-#               docs/guides/free-llm-setup.md の「モデル選択と max_tokens」を参照
+# https://openrouter.ai に登録して API キーを取得
+# 詳細（レート制限・無料モデル選択）: docs/guides/free-llm-setup.md
+# 無料モデル一覧: https://openrouter.ai/collections/free-models
 # LLM_API_KEY=YOUR_OPENROUTER_API_KEY
 # LLM_BASE_URL=https://openrouter.ai/api
-# 無料モデルの場合は以下をいずれかに変更（コメント解除）
-# LLM_MODEL=meta-llama/llama-3.3-70b-instruct:free
-# LLM_MODEL=deepseek/deepseek-r1:free
-# LLM_MODEL=qwen/qwen3-coder:free
+# LLM_MODEL=openrouter/owl-alpha  # 動作確認済みの無料モデル例
 
 # --- Option C: Ollama（代替・ローカル無料） ---
 # Ollama をローカルで起動している場合に切り替え

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -11,7 +11,7 @@ LLM_API_KEY=YOUR_ANTHROPIC_API_KEY
 # --- Option B: OpenRouter（代替・無料） ---
 # https://openrouter.ai に登録して API キーを取得（無料モデル利用可）
 # 以下を有効化して使用
-#   レート制限: 20 req/min, 50 req/day（$10 入金で 1000 req/day へ緩和）
+#   レート制限: 20 req/min, 50 req/day（$10 入金で 1,000 req/day へ緩和）
 #   max_tokens: 個別リクエスト制限なし。モデルの Max Output に従う
 #               統合 Agent (max_tokens=8000) 要件を満たす無料モデルは
 #               docs/guides/free-llm-setup.md の「モデル別の max output tokens 上限」を参照

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -14,7 +14,7 @@ LLM_API_KEY=YOUR_ANTHROPIC_API_KEY
 #   レート制限: 20 req/min, 50 req/day（$10 入金で 1,000 req/day へ緩和）
 #   max_tokens: 個別リクエスト制限なし。モデルの Max Output に従う
 #               統合 Agent (max_tokens=8000) 要件を満たす無料モデルは
-#               docs/guides/free-llm-setup.md の「モデル別の max output tokens 上限」を参照
+#               docs/guides/free-llm-setup.md の「モデル選択と max_tokens」を参照
 # LLM_API_KEY=YOUR_OPENROUTER_API_KEY
 # LLM_BASE_URL=https://openrouter.ai/api
 # 無料モデルの場合は以下をいずれかに変更（コメント解除）

--- a/docs/adr/0029-free-llm-api-selection.md
+++ b/docs/adr/0029-free-llm-api-selection.md
@@ -82,9 +82,9 @@ LLM_API_KEY=YOUR_ANTHROPIC_API_KEY
 
 **利用可能な無料モデル**（2026 年 5 月時点）:
 
-- Llama 3.3 70B — 高品質な汎用モデル
-- DeepSeek R1 — 推論タスク向け
-- qwen/qwen3-coder:free — コード生成向け
+- `meta-llama/llama-3.3-70b-instruct:free` — 高品質な汎用モデル
+- `deepseek/deepseek-r1:free` — 推論タスク向け
+- `qwen/qwen3-coder:free` — コード生成向け
 - その他 26+ モデル
 
 **特徴**:

--- a/docs/adr/0029-free-llm-api-selection.md
+++ b/docs/adr/0029-free-llm-api-selection.md
@@ -84,7 +84,7 @@ LLM_API_KEY=YOUR_ANTHROPIC_API_KEY
 
 - Llama 3.3 70B — 高品質な汎用モデル
 - DeepSeek R1 — 推論タスク向け
-- Qwen 3 Coder 480B — コード生成向け
+- qwen/qwen3-coder:free — コード生成向け
 - その他 26+ モデル
 
 **特徴**:

--- a/docs/design/llm-integration.md
+++ b/docs/design/llm-integration.md
@@ -31,7 +31,7 @@ Claude API を用いた LLM 呼び出しの設計方針。`packages/agent-core/s
 
 `top_p`, `top_k` はデフォルト値（未指定）とする。temperature で十分に制御できるため。
 
-> **プロバイダー切替時の注意**: `max_tokens=8000` はモデル側の Max Output Tokens 内に収まる必要がある。Anthropic 本家・OpenRouter 主要無料モデル（DeepSeek R1 / Llama 3.3 70B 等）は満たすが、低トークン制限のプロバイダー（例: Cerebras 無料枠の context cap 8,192）では出力が切れる可能性がある。切替時のチェックリストは [free-llm-setup.md](../guides/free-llm-setup.md#プロバイダー切替時のチェックリスト) 参照。
+> **プロバイダー切替時の注意**: `max_tokens=8000` はモデル側の Max Output Tokens 内に収まる必要がある。Anthropic 本家・OpenRouter 主要無料モデル（DeepSeek R1 / Llama 3.3 70B 等）は満たすが、低トークン制限のプロバイダー（例: Cerebras 無料枠は context cap 8,192 のため入出力合計が窮屈で 8,000 tokens の出力を確保できない）では採用できない。切替時は `docs/guides/free-llm-setup.md` のチェックリストを参照。
 
 ## ストリーミング方式
 

--- a/docs/design/llm-integration.md
+++ b/docs/design/llm-integration.md
@@ -31,7 +31,7 @@ Claude API を用いた LLM 呼び出しの設計方針。`packages/agent-core/s
 
 `top_p`, `top_k` はデフォルト値（未指定）とする。temperature で十分に制御できるため。
 
-> **プロバイダー切替時の注意**: `max_tokens=8000` はモデル側の Max Output Tokens 内に収まる必要がある。Anthropic 本家・OpenRouter 主要無料モデル（DeepSeek R1 / Llama 3.3 70B 等）は満たすが、低トークン制限のプロバイダー（例: Cerebras 無料枠は context cap 8,192 のため入出力合計が窮屈で 8,000 tokens の出力を確保できない）では採用できない。切替時は `docs/guides/free-llm-setup.md` のチェックリストを参照。
+> **プロバイダー切替時の注意**: `max_tokens=8000` はモデル側の Max Output Tokens 内に収まる必要がある。Anthropic 本家・OpenRouter 主要無料モデル（DeepSeek R1 / Llama 3.3 70B 等）は満たすが、低トークン制限のプロバイダー（例: Cerebras 無料枠は context cap 8,192 のため入出力合計が窮屈で 8,000 tokens の出力を確保できない）では採用できない。
 
 ## ストリーミング方式
 

--- a/docs/design/llm-integration.md
+++ b/docs/design/llm-integration.md
@@ -31,6 +31,8 @@ Claude API を用いた LLM 呼び出しの設計方針。`packages/agent-core/s
 
 `top_p`, `top_k` はデフォルト値（未指定）とする。temperature で十分に制御できるため。
 
+> **プロバイダー切替時の注意**: `max_tokens=8000` はモデル側の Max Output Tokens 内に収まる必要がある。Anthropic 本家・OpenRouter 主要無料モデル（DeepSeek R1 / Llama 3.3 70B 等）は満たすが、低トークン制限のプロバイダー（例: Cerebras 無料枠の context cap 8,192）では出力が切れる可能性がある。切替時のチェックリストは [free-llm-setup.md](../guides/free-llm-setup.md#プロバイダー切替時のチェックリスト) 参照。
+
 ## ストリーミング方式
 
 Anthropic SDK の streaming API を使い、トークン単位でクライアントに中継する。

--- a/docs/guides/free-llm-setup.md
+++ b/docs/guides/free-llm-setup.md
@@ -19,7 +19,7 @@ LLM API の選択
   │  │  └─ OpenRouter（無料モデル）
   │  │     - セットアップが簡単
   │  │     - スケーラブル
-  │  │     - レート制限: 20 req/min, 50 req/day
+  │  │     - レート制限: 20 req/min, 50 req/day（$10 入金で 1000 req/day）
   │  │
   │  └─ ローカル実行、無制限実行したい
   │     └─ Ollama
@@ -99,16 +99,27 @@ LLM API の選択
    bun run test
    ```
 
+### モデル別の max output tokens 上限
+
+本プロジェクトの統合 Agent は `max_tokens=8000` を要求する（3 社 × 4 観点のマトリクス生成で 3000 では出力切れになることを #205 ドッグフーディングで確認）。OpenRouter は**個別リクエストの max_tokens を制限せず**、モデルごとの最大出力に従う。以下の無料モデルは 8000 tokens 出力を満たす：
+
+| モデル ID | Context | Max Output | 統合 Agent (8000) |
+| --- | --- | --- | --- |
+| `deepseek/deepseek-r1:free` | 164K | 16,000 | OK |
+| `meta-llama/llama-3.3-70b-instruct:free` | 131K | 32,768 | OK |
+| `qwen/qwen3-coder:free` | 256K | 16,000 | OK |
+
+実利用前に [openrouter.ai/models](https://openrouter.ai/models) で対象モデルの "Max Output" を確認してください（モデルや時期により更新されます）。
+
 ### レート制限の注意
 
-無料ティアのレート制限（クレジット未購入時）:
+無料ティアのレート制限:
 
-- 20 requests/minute
-- 50 requests/day（リセット: UTC 00:00）
+- 20 requests/minute（共通）
+- 50 requests/day（クレジット未購入時、リセット: UTC 00:00）
+- 1,000 requests/day（10 USD 以上のクレジット購入で緩和）
 
-注: 10 以上のクレジット購入で 1000 requests/day に緩和されます。
-
-**制限値の評価**: Investigation Agent 4 つを並列実行した場合、単一実行で ~5 リクエスト消費するため、50 req/day では実運用に不十分。必要に応じて Ollama への切り替えや OpenRouter へのクレジット投入を検討してください。
+**制限値の評価**: Investigation Agent 4 つ + Integration Agent 1 つで 1 実行あたり ~5 リクエスト消費するため、無購入だと 1 日 ~10 実行が上限。継続検証では Ollama への切り替えか OpenRouter へのクレジット投入を検討してください。
 
 ---
 
@@ -187,6 +198,10 @@ LLM API の選択
 | Llama 3.3 70B | 40GB+ | NVIDIA/Metal | MacBook Pro M2 Max, RTX 4080/4090 |
 | Llama 3.1 405B | 1.5TB+ | 8x A100/H100（80GB各） | 非推奨（エンタープライズ環境向け） |
 
+### max_tokens の確認
+
+Ollama は Modelfile の `num_predict` でモデルごとに出力上限が定義される（既定は無制限〜モデル定義値）。統合 Agent の `max_tokens=8000` を満たすには 70B 級モデル（Llama 3.3 70B 等）を推奨。7B 級は出力品質も低下しがちなので、競合調査用途では `bun run test` の出力で品質を確認してから本番投入してください。
+
 ---
 
 ## 設定値の確認
@@ -254,6 +269,27 @@ cat apps/api/.env.local
 
 - **OpenRouter**: セットアップが簡単、スケーラブル、レート制限あり
 - **Ollama**: 完全無料・無制限、ローカルスペック必要
+
+---
+
+## プロバイダー切替時のチェックリスト
+
+新しい LLM プロバイダーへ切り替える前に以下を確認する。`max_tokens_by_role.integration=8000` がプロジェクトの最低要件（[llm-integration.md](../design/llm-integration.md) 参照）。
+
+1. **Anthropic 互換 endpoint を提供しているか** — `/v1/messages` を実装していること。OpenAI 互換のみの場合は `llm-client.ts` の SDK 境界拡張が別途必要（[ADR-0020](../adr/0020-llm-sdk-selection.md) §Decision 2）
+2. **対象モデルの Max Output Tokens が 8000 以上か** — 統合 Agent の出力切れを防ぐため
+3. **対象モデルの Context Window が ~12K 以上か** — 入力 ~4K + 出力 ~8K を収容するため
+4. **レート制限が実運用に耐えるか** — 1 実行で ~5 リクエスト消費を基準に評価
+
+### 不採用プロバイダー（参考）
+
+調査済みだが現状の SDK 境界（Anthropic SDK ネイティブ）では採用しない選択肢。SDK 境界拡張を行う場合の候補として参考までに記録する。
+
+| プロバイダー | 無料枠 | Max Output | Anthropic 互換 | 不採用理由 |
+| --- | --- | --- | --- | --- |
+| Groq | 30 RPM / 1000 RPD / TPM 6,000 | モデル依存 | ❌（OpenAI 互換のみ） | TPM 6,000 では 1 リクエストで 8000 tokens 出力が上限超過 |
+| Google Gemini Flash | 1,500 RPD / 1M TPM | 無制限 | ❌（gateway 経由のみ） | SDK 境界拡張が必要 |
+| Cerebras | 1M tokens/day | context cap 8,192 | ❌（OpenAI 互換のみ） | context cap が 8,192 で入力+出力が窮屈 |
 
 ---
 

--- a/docs/guides/free-llm-setup.md
+++ b/docs/guides/free-llm-setup.md
@@ -304,7 +304,7 @@ cat apps/api/.env.local
 | --- | --- | --- | --- | --- |
 | Groq | 30 RPM / 1000 RPD / TPM 6,000 | モデル依存 | ❌（OpenAI 互換のみ） | TPM 6,000 では 1 リクエストで 8000 tokens 出力が上限超過 |
 | Google Gemini Flash | 1,500 RPD / 1M TPM | 無制限 | ❌（gateway 経由のみ） | SDK 境界拡張が必要 |
-| Cerebras | 1M tokens/day | context cap 8,192 | ❌（OpenAI 互換のみ） | context cap が 8,192 で入力+出力が窮屈 |
+| Cerebras | 1M tokens/day | — (context cap 8,192 で制約) | ❌（OpenAI 互換のみ） | context cap が 8,192 で入力+出力が窮屈 |
 
 ---
 

--- a/docs/guides/free-llm-setup.md
+++ b/docs/guides/free-llm-setup.md
@@ -19,7 +19,7 @@ LLM API の選択
   │  │  └─ OpenRouter（無料モデル）
   │  │     - セットアップが簡単
   │  │     - スケーラブル
-  │  │     - レート制限: 20 req/min, 50 req/day（$10 のクレジット購入で 1,000 req/day）
+  │  │     - レート制限: 20 req/min, 50 req/day（$10 入金で 1,000 req/day へ緩和）
   │  │
   │  └─ ローカル実行、無制限実行したい
   │     └─ Ollama
@@ -117,7 +117,7 @@ LLM API の選択
 
 - 20 requests/minute（共通）
 - 50 requests/day（クレジット未購入時、リセット: UTC 00:00）
-- 1,000 requests/day（$10 以上のクレジット購入で緩和）
+- 1,000 requests/day（$10 入金で緩和）
 
 **制限値の評価**: Investigation Agent 4 つ + Integration Agent 1 つで 1 実行あたり ~5 リクエスト消費するため、無購入だと 1 日 ~10 実行が上限。継続検証では Ollama への切り替えか OpenRouter へのクレジット投入を検討してください。
 

--- a/docs/guides/free-llm-setup.md
+++ b/docs/guides/free-llm-setup.md
@@ -19,7 +19,7 @@ LLM API の選択
   │  │  └─ OpenRouter（無料モデル）
   │  │     - セットアップが簡単
   │  │     - スケーラブル
-  │  │     - レート制限: 20 req/min, 50 req/day（$10 入金で 1000 req/day）
+  │  │     - レート制限: 20 req/min, 50 req/day（$10 のクレジット購入で 1,000 req/day）
   │  │
   │  └─ ローカル実行、無制限実行したい
   │     └─ Ollama
@@ -81,13 +81,13 @@ LLM API の選択
 
    ```bash
    # 汎用モデル（推奨）
-   LLM_MODEL=llama-3.3-70b-specdec  # Llama 3.3 70B
+   LLM_MODEL=meta-llama/llama-3.3-70b-instruct:free  # Llama 3.3 70B
 
    # または推論タスク向け
-   LLM_MODEL=deepseek-r1  # DeepSeek R1
+   LLM_MODEL=deepseek/deepseek-r1:free  # DeepSeek R1
 
    # または コード生成向け
-   LLM_MODEL=qwen/qwen-coder-480b  # Qwen 3 Coder 480B
+   LLM_MODEL=qwen/qwen3-coder:free  # Qwen 3 Coder
    ```
 
    利用可能なモデル一覧: [openrouter.ai/models](https://openrouter.ai/models)
@@ -117,7 +117,7 @@ LLM API の選択
 
 - 20 requests/minute（共通）
 - 50 requests/day（クレジット未購入時、リセット: UTC 00:00）
-- 1,000 requests/day（10 USD 以上のクレジット購入で緩和）
+- 1,000 requests/day（$10 以上のクレジット購入で緩和）
 
 **制限値の評価**: Investigation Agent 4 つ + Integration Agent 1 つで 1 実行あたり ~5 リクエスト消費するため、無購入だと 1 日 ~10 実行が上限。継続検証では Ollama への切り替えか OpenRouter へのクレジット投入を検討してください。
 
@@ -200,7 +200,7 @@ LLM API の選択
 
 ### max_tokens の確認
 
-Ollama は Modelfile の `num_predict` でモデルごとに出力上限が定義される（既定は無制限〜モデル定義値）。統合 Agent の `max_tokens=8000` を満たすには 70B 級モデル（Llama 3.3 70B 等）を推奨。7B 級は出力品質も低下しがちなので、競合調査用途では `bun run test` の出力で品質を確認してから本番投入してください。
+Ollama は Modelfile の `num_predict` でモデルごとに出力上限が定義される（既定は `-1` = 無制限）。統合 Agent の `max_tokens=8000` を満たすには 70B 級モデル（Llama 3.3 70B 等）を推奨。7B 級は出力品質も低下しがちなので、競合調査用途では `bun run test` の出力で品質を確認してから本番投入してください。
 
 ---
 
@@ -276,9 +276,9 @@ cat apps/api/.env.local
 
 新しい LLM プロバイダーへ切り替える前に以下を確認する。`max_tokens_by_role.integration=8000` がプロジェクトの最低要件（[llm-integration.md](../design/llm-integration.md) 参照）。
 
-1. **Anthropic 互換 endpoint を提供しているか** — `/v1/messages` を実装していること。OpenAI 互換のみの場合は `llm-client.ts` の SDK 境界拡張が別途必要（[ADR-0020](../adr/0020-llm-sdk-selection.md) §Decision 2）
+1. **Anthropic 互換 endpoint を提供しているか** — `/v1/messages` を実装していること。OpenAI 互換のみの場合は `llm-client.ts` の SDK 境界拡張が別途必要（[ADR-0020](../adr/0020-llm-sdk-selection.md)）
 2. **対象モデルの Max Output Tokens が 8000 以上か** — 統合 Agent の出力切れを防ぐため
-3. **対象モデルの Context Window が ~12K 以上か** — 入力 ~4K + 出力 ~8K を収容するため
+3. **対象モデルの Context Window が ~13K 以上か** — 入力 ~4.4K + 出力 ~8K = ~12.4K を収容するため
 4. **レート制限が実運用に耐えるか** — 1 実行で ~5 リクエスト消費を基準に評価
 
 ### 不採用プロバイダー（参考）

--- a/docs/guides/free-llm-setup.md
+++ b/docs/guides/free-llm-setup.md
@@ -99,27 +99,42 @@ LLM API の選択
    bun run test
    ```
 
-### モデル別の max output tokens 上限
+### モデル選択と max_tokens
 
-本プロジェクトの統合 Agent は `max_tokens=8000` を要求する（3 社 × 4 観点のマトリクス生成で 3000 では出力切れになることを #205 ドッグフーディングで確認）。OpenRouter は**個別リクエストの max_tokens を制限せず**、モデルごとの最大出力に従う。以下の無料モデルは 8000 tokens 出力を満たす：
+本プロジェクトの統合 Agent は `max_tokens=8000` を要求する（3 社 × 4 観点のマトリクス生成で 3000 では出力切れになることを #205 ドッグフーディングで確認）。OpenRouter は個別リクエストの `max_tokens` を制限せず、モデルごとの Max Output に従う。要件を満たす無料モデルの選択は以下を参照：
 
-| モデル ID | Context | Max Output | 統合 Agent (8000) |
-| --- | --- | --- | --- |
-| `deepseek/deepseek-r1:free` | 164K | 16,000 | OK |
-| `meta-llama/llama-3.3-70b-instruct:free` | 131K | 32,768 | OK |
-| `qwen/qwen3-coder:free` | 256K | 16,000 | OK |
-
-実利用前に [openrouter.ai/models](https://openrouter.ai/models) で対象モデルの "Max Output" を確認してください（モデルや時期により更新されます）。
+- [openrouter.ai/models](https://openrouter.ai/models) で `Free` フィルタを適用し、Max Output が 8K 以上のモデルを選ぶ
+- `:free` モデルのカタログは頻繁に変動するため、本ガイドにモデル一覧は記載しない（陳腐化を避けるため）
 
 ### レート制限の注意
 
-無料ティアのレート制限:
+無料ティアのレート制限は **2 段構え**で、後者が実用上のボトルネックになりやすい。
+
+#### 1. OpenRouter 全体の制限
 
 - 20 requests/minute（共通）
 - 50 requests/day（クレジット未購入時、リセット: UTC 00:00）
 - 1,000 requests/day（$10 入金で緩和）
 
-**制限値の評価**: Investigation Agent 4 つ + Integration Agent 1 つで 1 実行あたり ~5 リクエスト消費するため、無購入だと 1 日 ~10 実行が上限。継続検証では Ollama への切り替えか OpenRouter へのクレジット投入を検討してください。
+#### 2. upstream provider の制限
+
+`:free` モデルは OpenRouter が複数の upstream provider にルーティングするが、無料バリアントは backup provider が限定的で、provider 側の rate limit を踏むと `429 (Provider rate-limited)` が頻発する。さらに provider が一斉に落ちると `404 (No endpoints found)` も発生する。
+
+```text
+例: 同一 API キーで連続リクエストすると 3 モデルとも同じ provider (Venice 等)
+    に振られ、1 つの provider 制限で全モデルが一時不通になる
+```
+
+**実運用の推奨**:
+
+- 動作確認・短時間の検証用途に留める
+- 本格運用は以下のいずれかを推奨:
+  - Anthropic 本家（Option A）
+  - OpenRouter で BYOK 設定（[Integrations 設定](https://openrouter.ai/settings/integrations) で Together / Groq 等の自前キーを登録すると自分のキー基準のレート制限になる）
+  - Ollama（Option C）でローカル実行
+- リトライ実装: Anthropic SDK の `maxRetries: 3` で 429 は自動リトライされるが、`retry_after_seconds` が長い場合は手動で別モデルへフォールバックも検討
+
+**制限値の評価**: Investigation Agent 4 つ + Integration Agent 1 つで 1 実行あたり ~5 リクエスト消費するため、無購入だと OpenRouter 全体制限で 1 日 ~10 実行が上限。加えて provider 制限で更に削れるため、継続検証では BYOK か Ollama 切替を検討してください。
 
 ---
 

--- a/docs/guides/free-llm-setup.md
+++ b/docs/guides/free-llm-setup.md
@@ -106,6 +106,21 @@ LLM API の選択
 - [openrouter.ai/collections/free-models](https://openrouter.ai/collections/free-models) で無料モデル一覧から Max Output が 8K 以上のモデルを選ぶ（`:free` 接尾辞なしの stealth モデル含む）
 - `:free` モデルのカタログは頻繁に変動するため、本ガイドにモデル一覧は記載しない（陳腐化を避けるため）
 
+#### 重要: 無料モデルでもクレジット入金が実質必要
+
+OpenRouter は `max_tokens` パラメータに基づく **pre-flight reservation（事前与信）** を行う。`:free` モデル（無料）であっても、`max_tokens` 分のコストをクレジット残高から予約しようとし、残高が足りないと 402 を返す。実際の応答が小さくても、`max_tokens` の上限値で予約される。
+
+```text
+例: max_tokens=1500 を要求し、利用可能枠が 756 tokens 分しか残っていない場合、
+    無料モデルでも以下のエラーで失敗:
+
+    LLM API error: 402
+    "This request requires more credits, or fewer max_tokens.
+     You requested up to 1500 tokens, but can only afford 756."
+```
+
+新規アカウントには小さな試用枠があるが、本プロジェクトの Investigation Agent (`max_tokens=1500`) / Integration Agent (`max_tokens=8000`) を継続実行するには **クレジット入金（$10〜）が事実上必須**。完全無料運用を希望する場合は Option C（Ollama）を選択してください。
+
 ### レート制限の注意
 
 無料ティアのレート制限は **2 段構え**で、後者が実用上のボトルネックになりやすい。

--- a/docs/guides/free-llm-setup.md
+++ b/docs/guides/free-llm-setup.md
@@ -90,7 +90,7 @@ LLM API の選択
    LLM_MODEL=qwen/qwen3-coder:free  # Qwen 3 Coder
    ```
 
-   利用可能なモデル一覧: [openrouter.ai/models](https://openrouter.ai/models)
+   利用可能な無料モデル一覧: [openrouter.ai/collections/free-models](https://openrouter.ai/collections/free-models)（`:free` 接尾辞付きと Owl Alpha 等の stealth モデル両方を網羅。全モデル検索は [openrouter.ai/models](https://openrouter.ai/models)）
 
 4. **動作確認**
 
@@ -103,7 +103,7 @@ LLM API の選択
 
 本プロジェクトの統合 Agent は `max_tokens=8000` を要求する（3 社 × 4 観点のマトリクス生成で 3000 では出力切れになることを #205 ドッグフーディングで確認）。OpenRouter は個別リクエストの `max_tokens` を制限せず、モデルごとの Max Output に従う。要件を満たす無料モデルの選択は以下を参照：
 
-- [openrouter.ai/models](https://openrouter.ai/models) で `Free` フィルタを適用し、Max Output が 8K 以上のモデルを選ぶ
+- [openrouter.ai/collections/free-models](https://openrouter.ai/collections/free-models) で無料モデル一覧から Max Output が 8K 以上のモデルを選ぶ（`:free` 接尾辞なしの stealth モデル含む）
 - `:free` モデルのカタログは頻繁に変動するため、本ガイドにモデル一覧は記載しない（陳腐化を避けるため）
 
 ### レート制限の注意


### PR DESCRIPTION
## What

ドッグフーディング #205 で発見した `max_tokens=8000` 要件と OpenRouter 無料枠の制約について再調査し、結果を文書化する。

- `docs/guides/free-llm-setup.md`
  - OpenRouter 無料モデル別の Max Output 上限一覧を追加（DeepSeek R1:free=16K, Llama 3.3 70B:free=32K, Qwen3 Coder:free=16K で `max_tokens=8000` を満たせる）
  - レート制限の正確化（50/日、$10 入金で 1000/日）
  - Ollama 用に `num_predict` の注記を追加
  - プロバイダー切替時のチェックリストを追加
  - 不採用プロバイダー一覧（Groq / Gemini Flash / Cerebras）を参考として記録
- `docs/design/llm-integration.md`
  - LLM パラメータ表の直後にプロバイダー切替時の注意を追記
- `apps/api/.env.example`
  - OpenRouter コメントにレート制限と max_tokens 注記を追記
  - 無料モデル ID を `:free` 接尾辞付きの正確な ID に修正

## Why

closes #212

調査の結果、Issue の前提（OpenRouter 無料枠の max_tokens 上限が 2048〜4096）は誤りで、OpenRouter は**個別リクエストの max_tokens を制限せず**、モデルの Max Output に従うことが判明した。本プロジェクトの `max_tokens=8000` は OpenRouter 無料モデルでも満たせる。

ただし開発者がプロバイダーを切り替えた際に「モデルごとの Max Output」「Context Window」「実効レート制限」を確認できる状態を整える必要があったため、本 PR で文書化する。

他プロバイダー（Groq / Gemini / Cerebras）も並行調査したが、いずれも Anthropic SDK ネイティブ互換を持たず、現状の `llm-client.ts` の SDK 境界（ADR-0020）では採用不可と判断した。

## How

- コード変更なし（OpenRouter 無料モデルが既に要件を満たすため）
- ADR-0029 は維持。再調査の結果は本 PR の文書化で十分と判断（ユーザー判断）

## Checklist

- [x] テストが通ること（コード変更なし。pre-commit hooks (lint:md / lint:secret / lint / type-check) は pass）
- [x] ドキュメントを更新したこと