### PR TITLE
chore(ci): sub_issues API への権限を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,6 +49,7 @@
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
       "Bash(gh api repos/:owner/:repo/issues:*)",
+      "Bash(gh api repos/:owner/:repo/issues/*/sub_issues:*)",
       "Bash(gh api -X POST repos/:owner/:repo/issues:*)",
       "Bash(gh api repos/:owner/:repo/milestones:*)",
       "Bash(gh api -X PATCH repos/:owner/:repo/milestones:*)",


### PR DESCRIPTION
## What

`.claude/settings.json` の `permissions.allow` に `Bash(gh api repos/:owner/:repo/issues/*/sub_issues:*)` を追加。

## Why

Sub-issues API（`gh api repos/:owner/:repo/issues/*/sub_issues`）を確認プロンプトなしで実行できるようにするため。読み取り専用の GET リクエストであり、安全性に問題なし。

## How

軽微な変更のため省略。

## Checklist

- [ ] テストが通ること（該当する場合）
- [ ] ドキュメントを更新したこと（該当する場合）