### PR TITLE
docs(skills): resolve-review に略称トリガー「rr」を追加

### DIFF
--- a/.claude/skills/resolve-review/SKILL.md
+++ b/.claude/skills/resolve-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resolve-review
 description: PR のレビュー指摘を読み取り、各指摘を評価・対応する。
-when_to_use: ユーザーが「レビュー対応して」「レビューコメント処理して」「指摘対応して」「レビュー修正して」「PR指摘直して」などと言ったとき
+when_to_use: ユーザーが「レビュー対応して」「レビューコメント処理して」「指摘対応して」「レビュー修正して」「PR指摘直して」「rr」（このスキルの略称。単独で言われた場合は resolve-review の起動意図か一言確認してから起動する）などと言ったとき
 argument-hint: "<pr-number>"
 allowed-tools: Bash(gh pr view:*) Bash(gh pr diff:*) Bash(gh pr comment:*) Bash(git status:*) Bash(git log:*) Bash(git diff:*) Bash(git branch:*) Bash(git add:*) Bash(git commit:*) Bash(bun run:*) Read Grep Glob Edit Write
 ---

--- a/.claude/skills/resolve-review/SKILL.md
+++ b/.claude/skills/resolve-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resolve-review
 description: PR のレビュー指摘を読み取り、各指摘を評価・対応する。
-when_to_use: ユーザーが「レビュー対応して」「レビューコメント処理して」「指摘対応して」「レビュー修正して」「PR指摘直して」「rr」（このスキルの略称。単独で言われた場合は resolve-review の起動意図か一言確認してから起動する）などと言ったとき
+when_to_use: ユーザーが「レビュー対応して」「レビューコメント処理して」「指摘対応して」「レビュー修正して」「PR指摘直して」「rr」（略称）などと言ったとき
 argument-hint: "<pr-number>"
 allowed-tools: Bash(gh pr view:*) Bash(gh pr diff:*) Bash(gh pr comment:*) Bash(git status:*) Bash(git log:*) Bash(git diff:*) Bash(git branch:*) Bash(git add:*) Bash(git commit:*) Bash(bun run:*) Read Grep Glob Edit Write
 ---
@@ -151,3 +151,4 @@ gh pr comment <pr-number> --body "<対応結果>"
 resolve-review 固有の注意点:
 
 - **競合する指摘**: フラグして選択を求める。勝手に片方を選ばない
+- **略称「rr」での起動**: `rr` 単独で呼ばれた場合は、resolve-review の起動意図かどうかを一言確認してから起動する


### PR DESCRIPTION
## What

`resolve-review` スキルの `when_to_use` に略称トリガー「rr」を追加した。短く曖昧な略称のため、単独で言われた場合は起動前に意図を確認する運用とする旨も併記している。

## Why

レビュー対応スキルを短い略称で呼び出せるようにするため。トリガーワード方式（`when_to_use` への追記のみ・可逆）で運用を試す。

## How

軽微な変更のため省略。

## Checklist

- [ ] テストが通ること（該当する場合）
- [x] ドキュメントを更新したこと（該当する場合）


---
_Generated by [Claude Code](https://claude.ai/code/session_01VEcbPXNxS4k78WJZoaDooj)_