### PR TITLE
feat(api): trace ID を API→engine→LLM の request flow に伝搬 (#239)

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -95,6 +95,11 @@ describe("GET /api/templates", () => {
     const traceId = body.details?.traceId;
     expect(traceId).toBeTruthy();
     expect(res.headers.get("X-Request-Id")).toBe(traceId ?? null);
+    // logging.md の trace ID 生成方針（RFC 4122 v4 UUID）に一致すること。
+    // hono/request-id の既定ジェネレータ形式が変わった場合に気づける。
+    expect(traceId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
   });
 });
 

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -197,6 +197,8 @@ describe("POST /api/executions", () => {
     });
 
     expect(res.status).toBe(202);
+    // 未呼び出し（captured===undefined）と引数誤りを区別できるよう先に存在を固定する。
+    expect(captured).toBeDefined();
     expect(captured?.executionId).toBe("exec-1");
     // X-Request-Id（=trace ID）と同形式の v4 UUID であること（logging.md）。
     expect(res.headers.get("X-Request-Id")).toBe(captured?.traceId ?? null);

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -175,6 +175,36 @@ describe("POST /api/executions", () => {
     });
   });
 
+  // #239: API→engine 境界での trace ID 伝搬の入口を固定する。
+  // route が c.get("requestId") を startExecution に渡し忘れた場合に検出できる。
+  test("startExecution に executionId と v4 UUID 形式の traceId が渡る", async () => {
+    let captured: { executionId: string; traceId: string } | undefined;
+    const app = buildApp({
+      getTemplateById: async () => fixtureTemplate,
+      createExecution: async () => ({
+        id: "exec-1",
+        status: "pending",
+        createdAt: "2026-05-04T00:00:00.000Z",
+      }),
+      startExecution: (executionId, traceId) => {
+        captured = { executionId, traceId };
+      },
+    });
+
+    const res = await postExecutions(app, {
+      templateId: fixtureTemplate.id,
+      parameters: validParameters,
+    });
+
+    expect(res.status).toBe(202);
+    expect(captured?.executionId).toBe("exec-1");
+    // X-Request-Id（=trace ID）と同形式の v4 UUID であること（logging.md）。
+    expect(res.headers.get("X-Request-Id")).toBe(captured?.traceId ?? null);
+    expect(captured?.traceId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
   test("Template 不在は 404 + ApiNotFoundError 形を返す", async () => {
     const app = buildApp({ getTemplateById: async () => null });
 

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -79,6 +79,23 @@ describe("GET /api/templates", () => {
     expect(body.message).toBeTruthy();
     expect(body.message).not.toContain("DB connection failed");
   });
+
+  // #239: 内部エラー時に details.traceId を露出し、X-Request-Id と一致させる。
+  test("500 応答の details.traceId が X-Request-Id ヘッダと一致する", async () => {
+    const app = buildApp({
+      listTemplateSummaries: async () => {
+        throw new Error("DB connection failed");
+      },
+    });
+
+    const res = await app.request("/api/templates");
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as ApiInternalError;
+    const traceId = body.details?.traceId;
+    expect(traceId).toBeTruthy();
+    expect(res.headers.get("X-Request-Id")).toBe(traceId ?? null);
+  });
 });
 
 describe("GET /api/templates/:id", () => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -47,8 +47,11 @@ export type AppDeps = {
   getResultByExecutionId: (executionId: string) => Promise<ResultRow | null>;
   /** 全 Execution 行を新しい順で取得する。 */
   listExecutions: () => Promise<ExecutionRow[]>;
-  /** 202 受理後に engine を非同期起動する（fire-and-forget）。 */
-  startExecution: (executionId: string) => void;
+  /**
+   * 202 受理後に engine を非同期起動する（fire-and-forget）。
+   * `traceId` は当該リクエストの request-id で、engine→LLM ログへ伝搬する（#239）。
+   */
+  startExecution: (executionId: string, traceId: string) => void;
   /**
    * Execution の AgentEvent を受け取るハンドラを登録し、解除関数を返す。
    * WS 切断時に解除関数を呼ぶこと。

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,7 +7,7 @@
  * Bun の serve には `fetch` と `websocket` の双方を渡す必要がある（hono/bun の規約）。
  */
 
-import type { AgentEvent } from "@agent-team-studio/agent-core";
+import type { AgentEvent, Logger } from "@agent-team-studio/agent-core";
 import { runExecution } from "@agent-team-studio/agent-core";
 import type { AgentExecutionRow } from "@agent-team-studio/db";
 import {
@@ -26,7 +26,7 @@ import {
 import type { AgentRole } from "@agent-team-studio/shared";
 import { createApp } from "./app.ts";
 import { createEventHub } from "./lib/event-hub.ts";
-import { type Logger, logger } from "./lib/logger.ts";
+import { logger } from "./lib/logger.ts";
 import { websocket } from "./lib/ws.ts";
 
 const databaseUrl = process.env.DATABASE_URL;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -26,7 +26,7 @@ import {
 import type { AgentRole } from "@agent-team-studio/shared";
 import { createApp } from "./app.ts";
 import { createEventHub } from "./lib/event-hub.ts";
-import { logger } from "./lib/logger.ts";
+import { type Logger, logger } from "./lib/logger.ts";
 import { websocket } from "./lib/ws.ts";
 
 const databaseUrl = process.env.DATABASE_URL;
@@ -38,16 +38,19 @@ const { db } = createDbClient(databaseUrl);
 
 const eventHub = createEventHub();
 
-// engine 経路は 202 受理後の fire-and-forget で HTTP request コンテキスト外のため、
-// request-id ではなく executionId を bind してログする（API→engine の ID 伝搬は #239）。
-const engineLogger = logger.child({ component: "engine" });
-
 /**
  * Execution を取得してエンジンを起動する。
+ *
+ * `engineLogger` は呼び出し元が trace ID(=request-id) と executionId を bind 済みの
+ * child logger。これを runExecution に注入することで API→engine→LLM のログが同一
+ * trace ID で引ける（#239）。
  * engine の `onEvent` コールバックで event hub に publish する。
  * engine が完了するまで非同期で実行される（呼び出し元は await しない）。
  */
-async function launchEngine(executionId: string): Promise<void> {
+async function launchEngine(
+  executionId: string,
+  engineLogger: Logger,
+): Promise<void> {
   const [execution, agentExecs] = await Promise.all([
     getExecution(db, executionId),
     getAgentExecutionsByExecutionId(db, executionId),
@@ -89,6 +92,7 @@ async function launchEngine(executionId: string): Promise<void> {
       updateAgentExecution: (id, patch) => updateAgentExecution(db, id, patch),
       insertResult: (input) => insertResult(db, input),
       onEvent: (event: AgentEvent) => eventHub.publish(executionId, event),
+      logger: engineLogger,
     },
   );
 }
@@ -103,9 +107,15 @@ const app = createApp({
   getResultByExecutionId: (executionId) =>
     getResultByExecutionId(db, executionId),
   listExecutions: () => listExecutions(db),
-  startExecution: (executionId) => {
-    launchEngine(executionId).catch((err) => {
-      engineLogger.error({ executionId, err }, "engine failed");
+  startExecution: (executionId, traceId) => {
+    // POST /api/executions の request-id を trace ID として engine 経路へ伝搬する。
+    const engineLogger = logger.child({
+      component: "engine",
+      requestId: traceId,
+      executionId,
+    });
+    launchEngine(executionId, engineLogger).catch((err) => {
+      engineLogger.error({ err }, "engine failed");
       eventHub.publish(executionId, {
         kind: "execution_failed",
         reason: "internal_error",

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -3,7 +3,8 @@
  *
  * Service / Route 層は `NotFoundError` / `ValidationError` を throw し、`onError`
  * ハンドラで API レスポンス形 + HTTP ステータスに整形する。内部例外（DB 接続失敗等）は
- * `internal_error` (500) に集約し、詳細漏洩を避けるため `details` は返さない。
+ * `internal_error` (500) に集約し、原因情報の漏洩を避けつつ相関用の `traceId`(=request-id)
+ * のみ `details` に含める（#239）。
  */
 
 import type {
@@ -77,9 +78,13 @@ export const onError: ErrorHandler<AppEnv> = (err, c) => {
   // ため、ログを欠落させない安全網として ?? でベースロガーへ退避する。
   (c.get("logger") ?? logger).error({ err }, "unhandled internal error");
 
+  // 原因情報は漏洩防止のため返さないが、相関用の traceId(=requestId) のみ露出する。
+  // requestId middleware より前で throw した稀なケースでは未 set のため details を省く。
+  const traceId = c.get("requestId");
   const body: ApiInternalError = {
     errorCode: "internal_error",
     message: "一時的なエラーが発生しました。時間をおいて再度お試しください",
+    ...(traceId ? { details: { traceId } } : {}),
   };
   return c.json(body, 500);
 };

--- a/apps/api/src/routes/executions.ts
+++ b/apps/api/src/routes/executions.ts
@@ -22,7 +22,7 @@ import type { ExecutionsService } from "../services/executions.ts";
 
 export function createExecutionsRoutes(deps: {
   executionsService: ExecutionsService;
-  startExecution: (executionId: string) => void;
+  startExecution: (executionId: string, traceId: string) => void;
 }) {
   const app = new Hono<AppEnv>();
 
@@ -40,7 +40,8 @@ export function createExecutionsRoutes(deps: {
       await deps.executionsService.createExecution(body);
 
     // 202 を返してから engine を非同期起動する（fire-and-forget）。
-    deps.startExecution(result.id);
+    // request-id を trace ID として engine 経路へ引き渡す（#239）。
+    deps.startExecution(result.id, c.get("requestId"));
 
     return c.json(result, 202);
   });

--- a/docs/design/logging.md
+++ b/docs/design/logging.md
@@ -29,12 +29,25 @@ bun run dev | pino-pretty
 
 `LOG_LEVEL` を明示指定した場合はそれが最優先。
 
-## request 相関（request-id）
+## request 相関 / trace ID（request-id）
 
 `hono/request-id` middleware が request ごとに request-id を払い出し（レスポンスヘッダ `X-Request-Id` にも付与）、それを bind した child logger を Hono context に格納する。アクセスログ・エラーログはこの request-scoped logger を用いるため、1 リクエストに紐づくログを request-id で横断的に追える。
 
-engine の fire-and-forget 経路（HTTP request コンテキスト外）は request-id を持たないため、`executionId` を bind する。API→engine→LLM への ID 伝搬は [Issue #239](https://github.com/kuairen-227/agent-team-studio/issues/239) の責務とする。
+`POST /api/executions` の request-id は **trace ID** として engine の fire-and-forget 経路（HTTP request コンテキスト外）へ伝搬する（[Issue #239](https://github.com/kuairen-227/agent-team-studio/issues/239)）。engine 起動時に `{ component: "engine", requestId, executionId }` を bind した child logger を生成し、agent ごとに `{ agentExecutionId, agentId, role }` を追加 bind した child を LLM 呼び出し層まで引き渡す。これにより HTTP→engine→agent→LLM のログを同一 trace ID で横断追跡できる。
 
+内部エラー（500）応答では原因情報を返さず、相関用に `details.traceId`（= request-id）のみを露出する（`packages/shared` の `ApiInternalError`）。
+
+### trace ID の生成方針
+
+| 項目 | 内容 |
+| --- | --- |
+| 生成 | `hono/request-id` の既定ジェネレータ `crypto.randomUUID()` |
+| 形式・長さ | RFC 4122 v4 UUID（36 文字、ハイフン区切り） |
+| 外部指定 | クライアントが `X-Request-Id` を送ると踏襲する。ただし 255 文字超または `\w` `-` `=` 以外を含む値は破棄して再生成（hono の既定検証） |
+| 衝突対策 | v4 は 122 bit ランダムで衝突確率は実質無視できる。短縮 ID は採用しない |
+
+> **命名の対応**: ログのフィールド名は `requestId`、API エラー応答の契約名は `details.traceId`、HTTP ヘッダは `X-Request-Id`。いずれも同一の値を指す。
+>
 > **エラー応答時のアクセスログ**: アクセスログ middleware は `await next()` 完了後に出力するため、ルート/サービス層が throw する経路（`onError` で整形される 400 / 404 / 500）では `"request completed"` を出力しない。500 は `onError` の error ログで追跡できるが、400 / 404 はアクセスログに残らない。全経路でのアクセスログ網羅は [Issue #256](https://github.com/kuairen-227/agent-team-studio/issues/256) で扱う。
 
 ## redact（機密フィールド除外）
@@ -48,6 +61,6 @@ engine の fire-and-forget 経路（HTTP request コンテキスト外）は req
 ## スコープ外
 
 - **apps/web**（ブラウザ）: フロントの可観測性は別途エラートラッキング（[Issue #237](https://github.com/kuairen-227/agent-team-studio/issues/237)）で扱う。
-- **packages/agent-core**（engine/LLM）: ライブラリのため具体ロガーに依存させない。logger 注入・ID 伝搬は [Issue #239](https://github.com/kuairen-227/agent-team-studio/issues/239) で扱う。
+- **packages/agent-core**（engine/LLM）: ライブラリのため具体ロガーに依存させない。最小 Logger ポート型（`logger-port.ts`）を定義し、apps/api が Pino logger を child binding して注入する（#239 で実装済み）。
 - **packages/db**: CLI スクリプト（migrate / seed）は人間が直接実行する運用ツールのため、構造化ログの対象外。
 - **WebSocket ハンドラ**: `onOpen` / `onMessage` 等は Hono の request context 外で動作するため request-scoped logger の対象外（現状エラーはログに残らない）。WS の可観測性は必要になった時点で別途検討する。

--- a/packages/agent-core/src/agent.test.ts
+++ b/packages/agent-core/src/agent.test.ts
@@ -441,7 +441,20 @@ describe("agent のロガー", () => {
     expect(errorLog?.fields.err).toBeDefined();
   });
 
+  test("出力パース失敗時は warn ログを err 付きで記録する", async () => {
+    const deps = makeDeps(["not valid json"]);
+    await runInvestigationAgent({ ...baseInvestigationInput }, deps);
+
+    const warnLog = deps.capturedLogs.find(
+      (l) => l.level === "warn" && l.msg === "llm output parse failed",
+    );
+    expect(warnLog).toBeDefined();
+    // "Invalid JSON" / "Invalid structure" の判別情報が握り潰されないことを固定する。
+    expect(warnLog?.fields.err).toBeDefined();
+  });
+
   test("注入された logger の bindings がログに伝搬する（trace ID 相当）", async () => {
+    // logger を override したケースでは sink に集約されるため deps.capturedLogs は使わない。
     const sink: LogCall[] = [];
     const bound = makeFakeLogger(sink, { requestId: "req-xyz" });
     const deps = makeDeps([validInvestigationJson], { logger: bound });
@@ -492,6 +505,7 @@ describe("runIntegrationAgent のロガー", () => {
   });
 
   test("注入された logger の bindings がログに伝搬する（trace ID 相当）", async () => {
+    // logger を override したケースでは sink に集約されるため deps.capturedLogs は使わない。
     const sink: LogCall[] = [];
     const bound = makeFakeLogger(sink, { requestId: "req-xyz" });
     const deps = makeDeps([validIntegrationRaw], { logger: bound });

--- a/packages/agent-core/src/agent.test.ts
+++ b/packages/agent-core/src/agent.test.ts
@@ -8,6 +8,31 @@ import type {
 import { runIntegrationAgent, runInvestigationAgent } from "./agent.ts";
 import type { AgentEvent } from "./events.ts";
 import type { LlmInput } from "./llm-client.ts";
+import { LlmError } from "./llm-error.ts";
+import type { LogFields, Logger } from "./logger-port.ts";
+
+// ---- fake logger ----
+
+type LogCall = {
+  level: "info" | "warn" | "error" | "debug";
+  fields: LogFields;
+  msg?: string;
+};
+
+/** bindings を logged fields にマージして sink に記録する fake logger。 */
+function makeFakeLogger(sink: LogCall[], bindings: LogFields = {}): Logger {
+  const record =
+    (level: LogCall["level"]) => (fields: LogFields, msg?: string) => {
+      sink.push({ level, fields: { ...bindings, ...fields }, msg });
+    };
+  return {
+    info: record("info"),
+    warn: record("warn"),
+    error: record("error"),
+    debug: record("debug"),
+    child: (b) => makeFakeLogger(sink, { ...bindings, ...b }),
+  };
+}
 
 // ---- フィクスチャ ----
 
@@ -76,9 +101,11 @@ function makeDeps(
 ): AgentDeps & {
   capturedPatches: Array<{ id: string; patch: AgentExecutionPatch }>;
   capturedEvents: AgentEvent[];
+  capturedLogs: LogCall[];
 } {
   const capturedPatches: Array<{ id: string; patch: AgentExecutionPatch }> = [];
   const capturedEvents: AgentEvent[] = [];
+  const capturedLogs: LogCall[] = [];
 
   async function* fakeStream(): AsyncIterable<string> {
     for (const chunk of streamChunks) {
@@ -100,8 +127,10 @@ function makeDeps(
       ((event: AgentEvent) => {
         capturedEvents.push(event);
       }),
+    logger: overrides?.logger ?? makeFakeLogger(capturedLogs),
     capturedPatches,
     capturedEvents,
+    capturedLogs,
   };
 }
 
@@ -379,5 +408,53 @@ describe("runIntegrationAgent", () => {
 
     expect(capturedSystem).toContain("CompanyA");
     expect(capturedSystem).toContain('"perspective"');
+  });
+});
+
+// ---- ロガー（trace ID 伝搬）テスト ----
+
+describe("agent のロガー", () => {
+  test("正常系: LLM 呼び出しの開始と完了を info ログに記録する", async () => {
+    const deps = makeDeps([validInvestigationJson]);
+    await runInvestigationAgent({ ...baseInvestigationInput }, deps);
+
+    const infoMessages = deps.capturedLogs
+      .filter((l) => l.level === "info")
+      .map((l) => l.msg);
+    expect(infoMessages).toContain("llm call started");
+    expect(infoMessages).toContain("llm call completed");
+  });
+
+  test("LLM 失敗時は error ログを記録する", async () => {
+    // biome-ignore lint/correctness/useYield: throw のみのストリームテスト用ジェネレーター
+    async function* errorStream(): AsyncIterable<string> {
+      throw new LlmError("llm_error", "API error");
+    }
+    const deps = makeDeps([], { stream: () => errorStream() });
+    await runInvestigationAgent({ ...baseInvestigationInput }, deps);
+
+    const errorMessages = deps.capturedLogs
+      .filter((l) => l.level === "error")
+      .map((l) => l.msg);
+    expect(errorMessages).toContain("llm call failed");
+  });
+
+  test("注入された logger の bindings がログに伝搬する（trace ID 相当）", async () => {
+    const sink: LogCall[] = [];
+    const bound = makeFakeLogger(sink, { requestId: "req-xyz" });
+    const deps = makeDeps([validInvestigationJson], { logger: bound });
+    await runInvestigationAgent({ ...baseInvestigationInput }, deps);
+
+    expect(sink.length).toBeGreaterThan(0);
+    expect(sink.every((l) => l.fields.requestId === "req-xyz")).toBe(true);
+  });
+
+  test("logger 未注入でも動作する（no-op フォールバック）", async () => {
+    const deps = makeDeps([validInvestigationJson]);
+    const result = await runInvestigationAgent(
+      { ...baseInvestigationInput },
+      { ...deps, logger: undefined },
+    );
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/agent-core/src/agent.test.ts
+++ b/packages/agent-core/src/agent.test.ts
@@ -500,4 +500,13 @@ describe("runIntegrationAgent のロガー", () => {
     expect(sink.length).toBeGreaterThan(0);
     expect(sink.every((l) => l.fields.requestId === "req-xyz")).toBe(true);
   });
+
+  test("logger 未注入でも動作する（no-op フォールバック）", async () => {
+    const deps = makeDeps([validIntegrationRaw]);
+    const result = await runIntegrationAgent(
+      { ...baseIntegrationInput },
+      { ...deps, logger: undefined },
+    );
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/agent-core/src/agent.test.ts
+++ b/packages/agent-core/src/agent.test.ts
@@ -422,7 +422,7 @@ describe("agent のロガー", () => {
       .filter((l) => l.level === "info")
       .map((l) => l.msg);
     expect(infoMessages).toContain("llm call started");
-    expect(infoMessages).toContain("llm call completed");
+    expect(infoMessages).toContain("agent completed");
   });
 
   test("LLM 失敗時は error ログを記録する", async () => {
@@ -433,10 +433,12 @@ describe("agent のロガー", () => {
     const deps = makeDeps([], { stream: () => errorStream() });
     await runInvestigationAgent({ ...baseInvestigationInput }, deps);
 
-    const errorMessages = deps.capturedLogs
-      .filter((l) => l.level === "error")
-      .map((l) => l.msg);
-    expect(errorMessages).toContain("llm call failed");
+    const errorLog = deps.capturedLogs.find(
+      (l) => l.level === "error" && l.msg === "llm call failed",
+    );
+    expect(errorLog).toBeDefined();
+    // err を渡し忘れても msg 一致だけでは通ってしまうため、err フィールドの伝搬も固定する。
+    expect(errorLog?.fields.err).toBeDefined();
   });
 
   test("注入された logger の bindings がログに伝搬する（trace ID 相当）", async () => {

--- a/packages/agent-core/src/agent.test.ts
+++ b/packages/agent-core/src/agent.test.ts
@@ -460,3 +460,44 @@ describe("agent のロガー", () => {
     expect(result.success).toBe(true);
   });
 });
+
+// runIntegrationAgent も runInvestigationAgent と同一の log.info/error 経路を持つため、
+// engine 経由（engine.test.ts）の間接検証だけでなく unit レベルでも固定する。
+describe("runIntegrationAgent のロガー", () => {
+  test("正常系: LLM 呼び出しの開始と完了を info ログに記録する", async () => {
+    const deps = makeDeps([validIntegrationRaw]);
+    await runIntegrationAgent({ ...baseIntegrationInput }, deps);
+
+    const infoMessages = deps.capturedLogs
+      .filter((l) => l.level === "info")
+      .map((l) => l.msg);
+    expect(infoMessages).toContain("llm call started");
+    expect(infoMessages).toContain("agent completed");
+  });
+
+  test("LLM 失敗時は error ログを記録する", async () => {
+    // biome-ignore lint/correctness/useYield: throw のみのストリームテスト用ジェネレーター
+    async function* errorStream(): AsyncIterable<string> {
+      throw new LlmError("llm_error", "API error");
+    }
+    const deps = makeDeps([], { stream: () => errorStream() });
+    await runIntegrationAgent({ ...baseIntegrationInput }, deps);
+
+    const errorLog = deps.capturedLogs.find(
+      (l) => l.level === "error" && l.msg === "llm call failed",
+    );
+    expect(errorLog).toBeDefined();
+    // err を渡し忘れても msg 一致だけでは通ってしまうため、err フィールドの伝搬も固定する。
+    expect(errorLog?.fields.err).toBeDefined();
+  });
+
+  test("注入された logger の bindings がログに伝搬する（trace ID 相当）", async () => {
+    const sink: LogCall[] = [];
+    const bound = makeFakeLogger(sink, { requestId: "req-xyz" });
+    const deps = makeDeps([validIntegrationRaw], { logger: bound });
+    await runIntegrationAgent({ ...baseIntegrationInput }, deps);
+
+    expect(sink.length).toBeGreaterThan(0);
+    expect(sink.every((l) => l.fields.requestId === "req-xyz")).toBe(true);
+  });
+});

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -41,6 +41,10 @@ export type AgentDeps = {
    * engine から agent 単位の bindings を載せて注入される。
    * 失敗時に `{ err }` をそのままログするため、message へ機密が混入しうる場合は
    * 注入側で加工する責務がある（{@link Logger} のドキュメント / logging.md §redact 参照）。
+   *
+   * 各ログ呼び出しは `{ agentId }` を明示的に添える。engine 経由では child logger 側に
+   * 既に `agentId` が bind 済みで冗長だが（Pino は後勝ちのため実害なし）、agent.ts を
+   * 単体で使う場合の追跡性を確保するために残している。
    */
   logger?: Logger;
 };

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -24,6 +24,7 @@ import type {
 import type { AgentEvent } from "./events.ts";
 import type { LlmInput } from "./llm-client.ts";
 import { LlmError } from "./llm-error.ts";
+import { type Logger, NOOP_LOGGER } from "./logger-port.ts";
 
 // ---------- 公開型 ----------
 
@@ -35,6 +36,11 @@ export type AgentDeps = {
     patch: AgentExecutionPatch,
   ) => Promise<void>;
   onEvent: (event: AgentEvent) => void;
+  /**
+   * trace ID 等を bind 済みの child logger。省略時は no-op。
+   * engine から agent 単位の bindings を載せて注入される。
+   */
+  logger?: Logger;
 };
 
 /** agent_executions テーブルへの書き込みパッチ型。 */
@@ -279,6 +285,7 @@ export async function runInvestigationAgent(
   input: InvestigationAgentRunInput,
   deps: AgentDeps,
 ): Promise<InvestigationResult> {
+  const log = deps.logger ?? NOOP_LOGGER;
   const startedAt = new Date();
   await deps.updateAgentExecution(input.agentExecutionId, {
     status: "running",
@@ -305,6 +312,7 @@ export async function runInvestigationAgent(
       max_tokens: input.llm.max_tokens_by_role.investigation,
     };
 
+    log.info({ agentId: input.agentId }, "llm call started");
     for await (const chunk of deps.stream(llmInput, input.signal)) {
       chunks.push(chunk);
       deps.onEvent({
@@ -323,6 +331,8 @@ export async function runInvestigationAgent(
   } catch {
     return handleParseFailure(input.agentExecutionId, input.agentId, deps);
   }
+
+  log.info({ agentId: input.agentId }, "llm call completed");
 
   const completedAt = new Date();
   await deps.updateAgentExecution(input.agentExecutionId, {
@@ -347,6 +357,7 @@ export async function runIntegrationAgent(
   input: IntegrationAgentRunInput,
   deps: AgentDeps,
 ): Promise<IntegrationResult> {
+  const log = deps.logger ?? NOOP_LOGGER;
   const startedAt = new Date();
   await deps.updateAgentExecution(input.agentExecutionId, {
     status: "running",
@@ -373,6 +384,7 @@ export async function runIntegrationAgent(
       max_tokens: input.llm.max_tokens_by_role.integration,
     };
 
+    log.info({ agentId: input.agentId }, "llm call started");
     for await (const chunk of deps.stream(llmInput, input.signal)) {
       chunks.push(chunk);
       deps.onEvent({
@@ -394,6 +406,8 @@ export async function runIntegrationAgent(
   } catch {
     return handleParseFailure(input.agentExecutionId, input.agentId, deps);
   }
+
+  log.info({ agentId: input.agentId }, "llm call completed");
 
   const completedAt = new Date();
   await deps.updateAgentExecution(input.agentExecutionId, {
@@ -419,6 +433,10 @@ async function handleAgentFailure(
 ): Promise<{ success: false; reason: AgentFailReason }> {
   const completedAt = new Date();
   const reason = toAgentFailReason(err);
+  (deps.logger ?? NOOP_LOGGER).error(
+    { agentId, reason, err },
+    "llm call failed",
+  );
   await deps.updateAgentExecution(agentExecutionId, {
     status: "failed",
     errorMessage: err instanceof Error ? err.message : String(err),
@@ -439,6 +457,7 @@ async function handleParseFailure(
   deps: AgentDeps,
 ): Promise<{ success: false; reason: "output_parse_error" }> {
   const completedAt = new Date();
+  (deps.logger ?? NOOP_LOGGER).warn({ agentId }, "llm output parse failed");
   await deps.updateAgentExecution(agentExecutionId, {
     status: "failed",
     errorMessage: "output_parse_error",

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -340,8 +340,14 @@ export async function runInvestigationAgent(
   let output: InvestigationAgentOutput;
   try {
     output = parseInvestigationOutput(chunks.join(""));
-  } catch {
-    return handleParseFailure(input.agentExecutionId, input.agentId, deps, log);
+  } catch (err) {
+    return handleParseFailure(
+      err,
+      input.agentExecutionId,
+      input.agentId,
+      deps,
+      log,
+    );
   }
 
   // パース成功まで含めた agent 完了を表す。"llm call started"（LLM 呼び出し開始）
@@ -424,8 +430,14 @@ export async function runIntegrationAgent(
     const parsed = parseIntegrationOutput(chunks.join(""));
     markdown = parsed.markdown;
     structured = parsed.structured;
-  } catch {
-    return handleParseFailure(input.agentExecutionId, input.agentId, deps, log);
+  } catch (err) {
+    return handleParseFailure(
+      err,
+      input.agentExecutionId,
+      input.agentId,
+      deps,
+      log,
+    );
   }
 
   // パース成功まで含めた agent 完了を表す（#264、runInvestigationAgent と同義）。
@@ -472,13 +484,16 @@ async function handleAgentFailure(
 }
 
 async function handleParseFailure(
+  err: unknown,
   agentExecutionId: string,
   agentId: string,
   deps: AgentDeps,
   log: Logger,
 ): Promise<{ success: false; reason: "output_parse_error" }> {
   const completedAt = new Date();
-  log.warn({ agentId }, "llm output parse failed");
+  // err には "Invalid JSON" / "Invalid structure" 等の判別情報が入るため診断目的で残す
+  // （handleAgentFailure の error ログと対称）。
+  log.warn({ agentId, err }, "llm output parse failed");
   await deps.updateAgentExecution(agentExecutionId, {
     status: "failed",
     errorMessage: "output_parse_error",

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -39,6 +39,8 @@ export type AgentDeps = {
   /**
    * trace ID 等を bind 済みの child logger。省略時は no-op。
    * engine から agent 単位の bindings を載せて注入される。
+   * 失敗時に `{ err }` をそのままログするため、message へ機密が混入しうる場合は
+   * 注入側で加工する責務がある（{@link Logger} のドキュメント / logging.md §redact 参照）。
    */
   logger?: Logger;
 };
@@ -322,17 +324,26 @@ export async function runInvestigationAgent(
       });
     }
   } catch (err) {
-    return handleAgentFailure(err, input.agentExecutionId, input.agentId, deps);
+    return handleAgentFailure(
+      err,
+      input.agentExecutionId,
+      input.agentId,
+      deps,
+      log,
+    );
   }
 
   let output: InvestigationAgentOutput;
   try {
     output = parseInvestigationOutput(chunks.join(""));
   } catch {
-    return handleParseFailure(input.agentExecutionId, input.agentId, deps);
+    return handleParseFailure(input.agentExecutionId, input.agentId, deps, log);
   }
 
-  log.info({ agentId: input.agentId }, "llm call completed");
+  // パース成功まで含めた agent 完了を表す。"llm call started"（LLM 呼び出し開始）
+  // と非対称だが、ここはストリーム受信後の出力パース成功を経た終端のため、
+  // LLM 応答受信ではなく agent 完了として記録する（#264）。
+  log.info({ agentId: input.agentId }, "agent completed");
 
   const completedAt = new Date();
   await deps.updateAgentExecution(input.agentExecutionId, {
@@ -394,7 +405,13 @@ export async function runIntegrationAgent(
       });
     }
   } catch (err) {
-    return handleAgentFailure(err, input.agentExecutionId, input.agentId, deps);
+    return handleAgentFailure(
+      err,
+      input.agentExecutionId,
+      input.agentId,
+      deps,
+      log,
+    );
   }
 
   let markdown: string;
@@ -404,10 +421,11 @@ export async function runIntegrationAgent(
     markdown = parsed.markdown;
     structured = parsed.structured;
   } catch {
-    return handleParseFailure(input.agentExecutionId, input.agentId, deps);
+    return handleParseFailure(input.agentExecutionId, input.agentId, deps, log);
   }
 
-  log.info({ agentId: input.agentId }, "llm call completed");
+  // パース成功まで含めた agent 完了を表す（#264、runInvestigationAgent と同義）。
+  log.info({ agentId: input.agentId }, "agent completed");
 
   const completedAt = new Date();
   await deps.updateAgentExecution(input.agentExecutionId, {
@@ -430,13 +448,11 @@ async function handleAgentFailure(
   agentExecutionId: string,
   agentId: string,
   deps: AgentDeps,
+  log: Logger,
 ): Promise<{ success: false; reason: AgentFailReason }> {
   const completedAt = new Date();
   const reason = toAgentFailReason(err);
-  (deps.logger ?? NOOP_LOGGER).error(
-    { agentId, reason, err },
-    "llm call failed",
-  );
+  log.error({ agentId, reason, err }, "llm call failed");
   await deps.updateAgentExecution(agentExecutionId, {
     status: "failed",
     errorMessage: err instanceof Error ? err.message : String(err),
@@ -455,9 +471,10 @@ async function handleParseFailure(
   agentExecutionId: string,
   agentId: string,
   deps: AgentDeps,
+  log: Logger,
 ): Promise<{ success: false; reason: "output_parse_error" }> {
   const completedAt = new Date();
-  (deps.logger ?? NOOP_LOGGER).warn({ agentId }, "llm output parse failed");
+  log.warn({ agentId }, "llm output parse failed");
   await deps.updateAgentExecution(agentExecutionId, {
     status: "failed",
     errorMessage: "output_parse_error",

--- a/packages/agent-core/src/engine.test.ts
+++ b/packages/agent-core/src/engine.test.ts
@@ -21,6 +21,30 @@ import type {
 import { runExecution } from "./engine.ts";
 import type { AgentEvent } from "./events.ts";
 import type { LlmInput } from "./llm-client.ts";
+import type { LogFields, Logger } from "./logger-port.ts";
+
+// ---- fake logger ----
+
+type LogCall = {
+  level: "info" | "warn" | "error" | "debug";
+  fields: LogFields;
+  msg?: string;
+};
+
+/** bindings を logged fields にマージして sink に記録する fake logger。 */
+function makeFakeLogger(sink: LogCall[], bindings: LogFields = {}): Logger {
+  const record =
+    (level: LogCall["level"]) => (fields: LogFields, msg?: string) => {
+      sink.push({ level, fields: { ...bindings, ...fields }, msg });
+    };
+  return {
+    info: record("info"),
+    warn: record("warn"),
+    error: record("error"),
+    debug: record("debug"),
+    child: (b) => makeFakeLogger(sink, { ...bindings, ...b }),
+  };
+}
 
 // ---- フィクスチャ ----
 
@@ -226,6 +250,26 @@ describe("runExecution", () => {
 
     const finalPatch = deps.executionPatches[deps.executionPatches.length - 1];
     expect(finalPatch?.patch.status).toBe("completed");
+  });
+
+  test("注入 logger の trace ID が agent ごとの child logger 経由で LLM 層ログまで伝搬する", async () => {
+    const sink: LogCall[] = [];
+    const deps: EngineRunDeps = {
+      ...makeFakeDeps(),
+      logger: makeFakeLogger(sink, { requestId: "req-1" }),
+    };
+    await runExecution(baseInput, deps);
+
+    // 全ログに requestId(trace ID) が乗っていること
+    expect(sink.length).toBeGreaterThan(0);
+    expect(sink.every((l) => l.fields.requestId === "req-1")).toBe(true);
+
+    // LLM 呼び出し層のログが agent 単位の bindings（agentId）付きで出ること
+    const llmStarted = sink.filter((l) => l.msg === "llm call started");
+    expect(llmStarted.length).toBeGreaterThan(0);
+    const agentIds = new Set(llmStarted.map((l) => l.fields.agentId));
+    expect(agentIds.has("investigation:strategy")).toBe(true);
+    expect(agentIds.has("integration:matrix")).toBe(true);
   });
 
   test("DB UPDATE → execution_completed イベント発行の順序を保証する", async () => {

--- a/packages/agent-core/src/engine.test.ts
+++ b/packages/agent-core/src/engine.test.ts
@@ -274,6 +274,12 @@ describe("runExecution", () => {
     // 並列実行される全 Investigation（ae-2）にも child logger が bind されること。
     expect(agentIds.has("investigation:product")).toBe(true);
     expect(agentIds.has("integration:matrix")).toBe(true);
+
+    // agentChildLogger が bind する agentExecutionId（並列追跡に必須）も付与されること。
+    // フィールド名が変わった場合に検出できるよう bind 契約を固定する。
+    expect(
+      llmStarted.every((l) => l.fields.agentExecutionId !== undefined),
+    ).toBe(true);
   });
 
   test("DB UPDATE → execution_completed イベント発行の順序を保証する", async () => {

--- a/packages/agent-core/src/engine.test.ts
+++ b/packages/agent-core/src/engine.test.ts
@@ -269,6 +269,8 @@ describe("runExecution", () => {
     expect(llmStarted.length).toBeGreaterThan(0);
     const agentIds = new Set(llmStarted.map((l) => l.fields.agentId));
     expect(agentIds.has("investigation:strategy")).toBe(true);
+    // 並列実行される全 Investigation（ae-2）にも child logger が bind されること。
+    expect(agentIds.has("investigation:product")).toBe(true);
     expect(agentIds.has("integration:matrix")).toBe(true);
   });
 

--- a/packages/agent-core/src/engine.test.ts
+++ b/packages/agent-core/src/engine.test.ts
@@ -215,6 +215,8 @@ function makeFakeDeps(
     onEvent: (event) => {
       events.push(event);
     },
+    // logger は意図的に省略し NOOP_LOGGER フォールバックを使う。trace ID 伝搬を
+    // 検証するテストのみ明示的に logger を上書きする（下記「trace ID」テスト参照）。
     _stream: streamFn ?? defaultStream,
     agentTimeoutMs: opts?.agentTimeoutMs,
     executionTimeoutMs: opts?.executionTimeoutMs,

--- a/packages/agent-core/src/engine.ts
+++ b/packages/agent-core/src/engine.ts
@@ -81,6 +81,23 @@ function findDefinition(
 }
 
 /**
+ * agent 単位の child logger を生成する。親（trace ID 等を bind 済み）に
+ * `agentExecutionId` / `agentId` / `role` を追加 bind して LLM 層へ渡す（#239）。
+ * Investigation 並列経路と Integration 経路で同一構造のため共通化し、
+ * フィールド追加・改名時の片側漏れ・typo を防ぐ。
+ */
+function agentChildLogger(
+  base: Logger | undefined,
+  ae: { id: string; agentId: string; role: AgentRole },
+): Logger {
+  return (base ?? NOOP_LOGGER).child({
+    agentExecutionId: ae.id,
+    agentId: ae.agentId,
+    role: ae.role,
+  });
+}
+
+/**
  * Promise.race 用のタイムアウト promise。
  * resolve ではなく reject することで race の勝者を明確にする。
  */
@@ -249,11 +266,7 @@ async function _runExecution(
         stream: streamFn,
         updateAgentExecution: deps.updateAgentExecution,
         onEvent: deps.onEvent,
-        logger: (deps.logger ?? NOOP_LOGGER).child({
-          agentExecutionId: integrationAe.id,
-          agentId: integrationAe.agentId,
-          role: integrationAe.role,
-        }),
+        logger: agentChildLogger(deps.logger, integrationAe),
       },
     );
   } finally {
@@ -350,11 +363,7 @@ async function runInvestigationsWithTimeout(
             stream: streamFn,
             updateAgentExecution: deps.updateAgentExecution,
             onEvent: deps.onEvent,
-            logger: (deps.logger ?? NOOP_LOGGER).child({
-              agentExecutionId: ae.id,
-              agentId: ae.agentId,
-              role: ae.role,
-            }),
+            logger: agentChildLogger(deps.logger, ae),
           },
         );
       } finally {

--- a/packages/agent-core/src/engine.ts
+++ b/packages/agent-core/src/engine.ts
@@ -22,6 +22,7 @@ import { runIntegrationAgent, runInvestigationAgent } from "./agent.ts";
 import { AGENT_TIMEOUT_MS, EXECUTION_TIMEOUT_MS } from "./constants.ts";
 import type { AgentEvent } from "./events.ts";
 import type { LlmInput } from "./llm-client.ts";
+import { type Logger, NOOP_LOGGER } from "./logger-port.ts";
 
 // ---------- 公開型 ----------
 
@@ -49,6 +50,11 @@ export type EngineRunDeps = {
   ) => Promise<void>;
   insertResult: (input: InsertResultInput) => Promise<string>;
   onEvent: (event: AgentEvent) => void;
+  /**
+   * trace ID 等を bind 済みの logger。省略時は no-op。
+   * runExecution が agent 単位の child logger を派生させ AgentDeps へ渡す。
+   */
+  logger?: Logger;
   /** テスト用: 注入された場合は streamAgentMessage の代わりに使う */
   _stream?: (input: LlmInput, signal?: AbortSignal) => AsyncIterable<string>;
   /** テスト用: エージェント単位タイムアウト ms（省略時は定数値を使用） */
@@ -243,6 +249,11 @@ async function _runExecution(
         stream: streamFn,
         updateAgentExecution: deps.updateAgentExecution,
         onEvent: deps.onEvent,
+        logger: (deps.logger ?? NOOP_LOGGER).child({
+          agentExecutionId: integrationAe.id,
+          agentId: integrationAe.agentId,
+          role: integrationAe.role,
+        }),
       },
     );
   } finally {
@@ -339,6 +350,11 @@ async function runInvestigationsWithTimeout(
             stream: streamFn,
             updateAgentExecution: deps.updateAgentExecution,
             onEvent: deps.onEvent,
+            logger: (deps.logger ?? NOOP_LOGGER).child({
+              agentExecutionId: ae.id,
+              agentId: ae.agentId,
+              role: ae.role,
+            }),
           },
         );
       } finally {

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -9,3 +9,5 @@ export type { AgentEvent } from "./events.ts";
 export type { LlmInput } from "./llm-client.ts";
 export { streamAgentMessage } from "./llm-client.ts";
 export { LlmError } from "./llm-error.ts";
+export type { LogFields, Logger } from "./logger-port.ts";
+export { NOOP_LOGGER } from "./logger-port.ts";

--- a/packages/agent-core/src/logger-port.ts
+++ b/packages/agent-core/src/logger-port.ts
@@ -7,6 +7,10 @@
  *
  * trace ID は呼び出し側が `child({ requestId })` で bind した logger を注入するため、
  * agent-core は ID 値を直接知らずにログへ伝搬できる（関心の分離）。
+ *
+ * 機密の取り扱い: redact はフィールド名ベースで `err.message` 等の文字列内は除去できない
+ * （docs/design/logging.md §redact）。`{ err }` をそのまま渡す場合、message に機密が
+ * 混入しうるなら**注入側が加工してから**ログする責務を負う（境界の責務はログ実装側）。
  */
 
 /** ログに添える構造化フィールド。 */

--- a/packages/agent-core/src/logger-port.ts
+++ b/packages/agent-core/src/logger-port.ts
@@ -1,0 +1,32 @@
+/**
+ * agent-core が依存するロガーの最小ポート型。
+ *
+ * apps→packages の逆依存（agent-core が apps/api の Pino 実装に依存すること）を避けるため、
+ * 構造的インターフェースのみを定義する。Pino の `Logger` はこの形に構造互換で、
+ * apps/api 側がそのまま注入できる。テストでは {@link NOOP_LOGGER} か fake を渡す。
+ *
+ * trace ID は呼び出し側が `child({ requestId })` で bind した logger を注入するため、
+ * agent-core は ID 値を直接知らずにログへ伝搬できる（関心の分離）。
+ */
+
+/** ログに添える構造化フィールド。 */
+export type LogFields = Record<string, unknown>;
+
+/** Pino と構造互換な最小ロガーインターフェース。 */
+export interface Logger {
+  info(obj: LogFields, msg?: string): void;
+  warn(obj: LogFields, msg?: string): void;
+  error(obj: LogFields, msg?: string): void;
+  debug(obj: LogFields, msg?: string): void;
+  /** bindings を引き継いだ子ロガーを返す。 */
+  child(bindings: LogFields): Logger;
+}
+
+/** ロガー未注入時のフォールバック。何も出力しない。 */
+export const NOOP_LOGGER: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  child: () => NOOP_LOGGER,
+};


### PR DESCRIPTION
## What

API リクエストの request-id を **trace ID** として `apps/api` → engine → LLM 呼び出し層まで貫通させ、ログから 1 実行のフローを横断追跡できるようにする。

- `packages/agent-core`: apps→packages 逆依存を避ける最小 `Logger` ポート型を新設。`EngineRunDeps` / `AgentDeps` に optional `logger` を追加し、engine が agent 単位（agentExecutionId / agentId / role を bind）の child logger を派生。agent 層が LLM 呼び出しの開始・完了・失敗をログ
- `apps/api`: `POST /api/executions` の request-id を `startExecution(id, traceId)` 経由で engine へ伝搬し、`{ component, requestId, executionId }` を bind した child logger を `runExecution` に注入。内部エラー(500)応答に `details.traceId` を露出
- `docs/design/logging.md`: trace ID の生成方針と伝搬を記載

## Why

closes #239

複数の Investigation / Integration エージェントが並列に LLM を呼ぶため、ログから個別実行のフローを同一 ID で追える仕組みは運用上の価値が高い。構造化 Logger (#236) と組み合わせて Observability セットを形成する。

## How

- **trace ID の正体**: 既存の `hono/request-id`（`crypto.randomUUID()` / UUID v4）を再利用。新規 ID は生成せず、HTTP→engine→LLM を 1 つの ID で貫通（fire-and-forget の engine 経路にも伝搬）
- **逆依存回避**: agent-core は具体ロガー（Pino）に依存させず、構造的 `Logger` ポート型のみ定義。Pino は構造互換で apps/api から注入（type-check で互換確認済み）
- **既存フロー非破壊**: 202 fire-and-forget・タイムアウト・onEvent 順序は不変。`logger` は optional + no-op フォールバックで既存テストの変更ゼロ
- **命名**: ログのフィールド名は `requestId`、API エラー応答の契約名は `details.traceId`、HTTP ヘッダは `X-Request-Id`。いずれも同一値（docs に明記）

### 受け入れ条件

- [x] 1 リクエストにつき 1 trace ID が生成され、サーバ側ログ全体で同一 ID が引ける
- [x] LLM 呼び出し層のログにも trace ID が付与される
- [x] error response の `details.traceId` に値が入る
- [x] trace ID の生成方針（形式・長さ・衝突対策）が docs に記録されている

## Checklist

- [x] テストが通ること（該当する場合）
- [x] ドキュメントを更新したこと（該当する場合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)