### PR TITLE
test(api): アクセスログ全経路出力を回帰テストで固定し docs を実態に修正 (#256)

### DIFF
--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -48,8 +48,11 @@ const postExecutions = (app: ReturnType<typeof buildApp>, body: unknown) =>
     body: JSON.stringify(body),
   });
 
-/** アクセスログ middleware が 1 リクエストごとに出力する行（#256）。 */
-type AccessLogEntry = {
+/**
+ * アクセスログ行のうち本テストがアサーション対象とするフィールドのみの**部分型**（#256）。
+ * pino が実際に出力する `level` / `time` / `requestId` 等は含まない。
+ */
+type AccessLogFields = {
   msg: string;
   method: string;
   path: string;
@@ -63,14 +66,19 @@ type AccessLogEntry = {
  * pino のベースロガー（singleton）は stdout へ JSON を書くため、書き込みを差し替えて捕捉する。
  * テスト環境のロガーは silent 既定（logger.test.ts）なので、捕捉の間だけ level を info に上げる。
  * いずれも `finally` で必ず復元する。
+ *
+ * 注意: `process.stdout.write` をプロセスグローバルに差し替えるため、bun test の並列実行が
+ * 有効な場合は他テストの stdout 出力が混入しうる。現状は単一ファイル内の直列実行で問題ない。
  */
 async function captureAccessLog<T>(
   makeRequest: () => T | Promise<T>,
-): Promise<{ result: T; accessLog?: AccessLogEntry }> {
+): Promise<{ result: T; accessLog?: AccessLogFields }> {
   const lines: string[] = [];
   const originalWrite = process.stdout.write.bind(process.stdout);
   const savedLevel = logger.level;
   logger.level = "info";
+  // Bun + pino(sonic-boom) は write を 1 引数（chunk）でしか呼ばないため、
+  // encoding / cb 引数を省いた簡略シグネチャでパッチし、型はキャストで合わせる。
   process.stdout.write = ((chunk: string | Uint8Array) => {
     lines.push(
       typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
@@ -89,7 +97,7 @@ async function captureAccessLog<T>(
   const accessLog = lines
     .map((line) => {
       try {
-        return JSON.parse(line) as AccessLogEntry;
+        return JSON.parse(line) as AccessLogFields;
       } catch {
         return undefined;
       }
@@ -527,10 +535,10 @@ describe("GET /api/executions/:id", () => {
   });
 });
 
-// #256: throw 経路（onError 整形の 400/404/500）でもアクセスログが出力され、
-// status が実レスポンスと一致することを固定する。Hono の compose は throw を捕捉した
-// 階層内で onError を同期実行して c.res を確定するため、middleware の `await next()` 後の
-// ログ出力時点では status が反映済みになる（docs/design/logging.md）。
+// #256: throw 経路（onError 整形の 400/404/500）と未マッチルート（onNotFound の 404）の
+// いずれでもアクセスログが出力され、status が実レスポンスと一致することを固定する。
+// Hono の compose は throw を捕捉した階層内で onError を同期実行して c.res を確定するため、
+// middleware の `await next()` 後のログ出力時点では status が反映済みになる（docs/design/logging.md）。
 // 将来 middleware を try/catch+rethrow 等へ変えてエラー経路のログを落とす退行を検知する。
 describe("アクセスログの全経路網羅", () => {
   test("400（validation）経路でアクセスログが status=400 で出力される", async () => {
@@ -558,9 +566,22 @@ describe("アクセスログの全経路網羅", () => {
     );
 
     expect(res.status).toBe(404);
+    expect(accessLog).toBeDefined();
     expect(accessLog?.status).toBe(404);
     expect(accessLog?.method).toBe("GET");
     expect(accessLog?.path).toBe("/api/templates/tpl-missing");
+  });
+
+  test("404（未マッチルート / onNotFound）経路でアクセスログが status=404 で出力される", async () => {
+    const app = buildApp();
+    const { result: res, accessLog } = await captureAccessLog(() =>
+      app.request("/no/such/route"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(accessLog).toBeDefined();
+    expect(accessLog?.status).toBe(404);
+    expect(accessLog?.path).toBe("/no/such/route");
   });
 
   test("500（throw）経路でアクセスログが status=500 で出力される", async () => {
@@ -574,6 +595,7 @@ describe("アクセスログの全経路網羅", () => {
     );
 
     expect(res.status).toBe(500);
+    expect(accessLog).toBeDefined();
     expect(accessLog?.status).toBe(500);
     expect(accessLog?.path).toBe("/api/templates");
   });

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -17,6 +17,7 @@ import type {
 } from "@agent-team-studio/shared";
 import { fixtureTemplate, fixtureTemplateSummaries } from "./_test-fixtures.ts";
 import { type AppDeps, createApp } from "./app.ts";
+import { logger } from "./lib/logger.ts";
 
 const buildApp = (overrides: Partial<AppDeps> = {}) =>
   createApp({
@@ -46,6 +47,56 @@ const postExecutions = (app: ReturnType<typeof buildApp>, body: unknown) =>
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
+
+/** アクセスログ middleware が 1 リクエストごとに出力する行（#256）。 */
+type AccessLogEntry = {
+  msg: string;
+  method: string;
+  path: string;
+  status: number;
+  latencyMs: number;
+};
+
+/**
+ * リクエスト実行中の stdout を捕捉し、アクセスログ（`"request completed"`）行を返す。
+ *
+ * pino のベースロガー（singleton）は stdout へ JSON を書くため、書き込みを差し替えて捕捉する。
+ * テスト環境のロガーは silent 既定（logger.test.ts）なので、捕捉の間だけ level を info に上げる。
+ * いずれも `finally` で必ず復元する。
+ */
+async function captureAccessLog<T>(
+  makeRequest: () => T | Promise<T>,
+): Promise<{ result: T; accessLog?: AccessLogEntry }> {
+  const lines: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const savedLevel = logger.level;
+  logger.level = "info";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    lines.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+    );
+    return true;
+  }) as typeof process.stdout.write;
+
+  let result: T;
+  try {
+    result = await makeRequest();
+  } finally {
+    process.stdout.write = originalWrite;
+    logger.level = savedLevel;
+  }
+
+  const accessLog = lines
+    .map((line) => {
+      try {
+        return JSON.parse(line) as AccessLogEntry;
+      } catch {
+        return undefined;
+      }
+    })
+    .find((entry) => entry?.msg === "request completed");
+  return { result, accessLog };
+}
 
 describe("GET /api/templates", () => {
   test("repo の戻り値を items + total 形で 200 で返す", async () => {
@@ -473,5 +524,57 @@ describe("GET /api/executions/:id", () => {
     const body = (await res.json()) as GetExecutionResponse;
     expect(body.id).toBe("exec-1");
     expect(body.result).toBeUndefined();
+  });
+});
+
+// #256: throw 経路（onError 整形の 400/404/500）でもアクセスログが出力され、
+// status が実レスポンスと一致することを固定する。Hono の compose は throw を捕捉した
+// 階層内で onError を同期実行して c.res を確定するため、middleware の `await next()` 後の
+// ログ出力時点では status が反映済みになる（docs/design/logging.md）。
+// 将来 middleware を try/catch+rethrow 等へ変えてエラー経路のログを落とす退行を検知する。
+describe("アクセスログの全経路網羅", () => {
+  test("400（validation）経路でアクセスログが status=400 で出力される", async () => {
+    const app = buildApp();
+    const { result: res, accessLog } = await captureAccessLog(() =>
+      app.request("/api/executions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not-json",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(accessLog).toBeDefined();
+    expect(accessLog?.status).toBe(400);
+    expect(accessLog?.method).toBe("POST");
+    expect(accessLog?.path).toBe("/api/executions");
+    expect(typeof accessLog?.latencyMs).toBe("number");
+  });
+
+  test("404（NotFoundError）経路でアクセスログが status=404 で出力される", async () => {
+    const app = buildApp({ getTemplateById: async () => null });
+    const { result: res, accessLog } = await captureAccessLog(() =>
+      app.request("/api/templates/tpl-missing"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(accessLog?.status).toBe(404);
+    expect(accessLog?.method).toBe("GET");
+    expect(accessLog?.path).toBe("/api/templates/tpl-missing");
+  });
+
+  test("500（throw）経路でアクセスログが status=500 で出力される", async () => {
+    const app = buildApp({
+      listTemplateSummaries: async () => {
+        throw new Error("DB connection failed");
+      },
+    });
+    const { result: res, accessLog } = await captureAccessLog(() =>
+      app.request("/api/templates"),
+    );
+
+    expect(res.status).toBe(500);
+    expect(accessLog?.status).toBe(500);
+    expect(accessLog?.path).toBe("/api/templates");
   });
 });

--- a/docs/design/logging.md
+++ b/docs/design/logging.md
@@ -48,7 +48,7 @@ bun run dev | pino-pretty
 
 > **命名の対応**: ログのフィールド名は `requestId`、API エラー応答の契約名は `details.traceId`、HTTP ヘッダは `X-Request-Id`。いずれも同一の値を指す。
 >
-> **エラー応答時のアクセスログ**: throw 経路（`onError` で整形される 400 / 404 / 500、および未マッチルートの `onNotFound`）でもアクセスログ（`"request completed"`）を 1 リクエスト 1 行で出力し、`status` は実レスポンスと一致する。Hono の `compose` は throw を捕捉した階層内で `onError` を同期実行して `c.res` を確定するため、アクセスログ middleware の `await next()` 完了後の出力時点で status は反映済みになる（[Issue #256](https://github.com/kuairen-227/agent-team-studio/issues/256)。退行検知は `apps/api/src/app.test.ts` のアクセスログ全経路テスト）。500 はこれに加え `onError` の error ログでも追跡できる。
+> **エラー応答時のアクセスログ**: throw 経路（`onError` で整形される 400 / 404 / 500、および未マッチルートの `onNotFound`）でもアクセスログ（`"request completed"`）を 1 リクエスト 1 行で出力し、`status` は実レスポンスと一致する。Hono の `compose` は throw を捕捉した階層内で `onError` を同期実行して `c.res` を確定するため、アクセスログ middleware の `await next()` 完了後の出力時点で status は反映済みになる（[Issue #256](https://github.com/kuairen-227/agent-team-studio/issues/256)）。500 はこれに加え `onError` の error ログでも追跡できる。退行検知は `apps/api/src/app.test.ts` のアクセスログ全経路テストで担保する。
 
 ## redact（機密フィールド除外）
 

--- a/docs/design/logging.md
+++ b/docs/design/logging.md
@@ -48,7 +48,7 @@ bun run dev | pino-pretty
 
 > **命名の対応**: ログのフィールド名は `requestId`、API エラー応答の契約名は `details.traceId`、HTTP ヘッダは `X-Request-Id`。いずれも同一の値を指す。
 >
-> **エラー応答時のアクセスログ**: アクセスログ middleware は `await next()` 完了後に出力するため、ルート/サービス層が throw する経路（`onError` で整形される 400 / 404 / 500）では `"request completed"` を出力しない。500 は `onError` の error ログで追跡できるが、400 / 404 はアクセスログに残らない。全経路でのアクセスログ網羅は [Issue #256](https://github.com/kuairen-227/agent-team-studio/issues/256) で扱う。
+> **エラー応答時のアクセスログ**: throw 経路（`onError` で整形される 400 / 404 / 500、および未マッチルートの `onNotFound`）でもアクセスログ（`"request completed"`）を 1 リクエスト 1 行で出力し、`status` は実レスポンスと一致する。Hono の `compose` は throw を捕捉した階層内で `onError` を同期実行して `c.res` を確定するため、アクセスログ middleware の `await next()` 完了後の出力時点で status は反映済みになる（[Issue #256](https://github.com/kuairen-227/agent-team-studio/issues/256)。退行検知は `apps/api/src/app.test.ts` のアクセスログ全経路テスト）。500 はこれに加え `onError` の error ログでも追跡できる。
 
 ## redact（機密フィールド除外）
 


### PR DESCRIPTION
## What

Issue #256（throw 経路でアクセスログが出力されない問題への対応）の調査・対応。

調査の結果、**現行コードでは throw 経路（`onError` 整形の 400/404/500、未マッチルートの `onNotFound`）でもアクセスログ（`"request completed"`）が正しい `status` とともに出力済み**であることが実測で判明した。Issue の前提（エラー応答時はアクセスログ未出力）は Hono の現行挙動では成立しないため、振る舞い変更は不要と判断し、以下に縮退した。

- `apps/api/src/app.test.ts`: 400/404/500 の各経路でアクセスログが出力され `status` が実レスポンスと一致することを固定する回帰テストを追加（`captureAccessLog` ヘルパで、テスト中だけ logger level を info に上げ stdout を捕捉、`finally` で復元）
- `docs/design/logging.md`: 「エラー応答時はアクセスログ未出力」の誤記述を、全経路出力・`status` 一致の実態と根拠に修正

## Why

closes #256

Issue は「アクセスログ middleware は `await next()` 後に出力するため throw 経路では出ない」を前提としていたが、Hono 4.12 の `compose` は throw を捕捉した dispatch 階層**内**で `onError` を同期実行して `c.res` を確定する。そのため上位の middleware の `await next()` は reject せず正常 resolve し、その後のログ出力時点で `c.res.status` は onError 整形済みの値になる。実 app に対する 200/400/404(NotFoundError)/404(onNotFound)/500 の実測でも全経路で出力を確認した。

このため本 PR はコードの振る舞いを変えず、(1) 現行挙動を退行から守る回帰テスト、(2) ドキュメントの実態整合、の 2 点に絞っている。`enhancement` ではなく `test` / `documentation` ラベルとした。

## How

- `captureAccessLog<T>()`: `process.stdout.write` を差し替えて pino のベースロガー（singleton）出力を捕捉。テスト環境は silent 既定（`logger.test.ts`）のため捕捉中のみ `logger.level = "info"`。状態はすべて `finally` で復元
- 退行検知の意図（middleware を try/catch+rethrow 等に変えてエラー経路のログを落とすケース）をテスト・docs 双方のコメントに明記

## Checklist

- [x] テストが通ること（`lint` / `lint:md` / `lint:md-links` / `lint:secret` / `type-check` / `test` 68 pass / `build` すべて緑）
- [x] ドキュメントを更新したこと（`docs/design/logging.md`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)