### PR TITLE
feat(web): 入力フォームに調査観点を常時表示し透明性を向上 (#228)

### DIFF
--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -433,7 +433,12 @@ function PerspectivesPanel({ agents }: { agents: AgentDefinition[] }) {
         {/* CardTitle は div を出力し asChild 非対応のため、見出し階層（h1 配下の
             セクション見出し）を保つよう CardTitle 相当のスタイルで h2 を直接描画する
             （WCAG 1.3.1）。 */}
-        <h2 className="font-heading text-base font-medium leading-snug">
+        {/* 視覚表示は全角括弧で既存 UI（参考情報（任意）等）に揃える。SR は括弧を
+            逐字読みするため aria-label で括弧を除いた文字列を明示する（WCAG 1.3.1）。 */}
+        <h2
+          className="font-heading text-base font-medium leading-snug"
+          aria-label={`調査される観点 ${perspectives.length} 観点`}
+        >
           調査される観点（{perspectives.length} 観点）
         </h2>
         <CardDescription>

--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -30,7 +30,6 @@ import {
   CardContent,
   CardDescription,
   CardHeader,
-  CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -431,17 +430,20 @@ function PerspectivesPanel({ agents }: { agents: AgentDefinition[] }) {
   return (
     <Card className="mb-6">
       <CardHeader>
-        <CardTitle className="text-base">
+        {/* CardTitle は div を出力し asChild 非対応のため、見出し階層（h1 配下の
+            セクション見出し）を保つよう CardTitle 相当のスタイルで h2 を直接描画する
+            （WCAG 1.3.1）。 */}
+        <h2 className="font-heading text-base font-medium leading-snug">
           調査される観点（{perspectives.length} 観点）
-        </CardTitle>
+        </h2>
         <CardDescription>
-          実行すると、以下の観点で競合企業を並行して調査します。
+          実行すると、以下の観点で競合企業を調査します。
         </CardDescription>
       </CardHeader>
       <CardContent>
         <ul className="space-y-2 text-sm">
           {perspectives.map((perspective) => (
-            <li key={perspective.key} className="leading-tight">
+            <li key={perspective.key} className="leading-normal">
               <span className="font-medium">{perspective.name}</span>
               <span className="text-muted-foreground">
                 {" "}

--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -441,9 +441,7 @@ function PerspectivesPanel({ agents }: { agents: AgentDefinition[] }) {
         >
           調査される観点（{perspectives.length} 観点）
         </h2>
-        <CardDescription>
-          実行すると、以下の観点で競合企業を調査します。
-        </CardDescription>
+        <CardDescription>以下の観点で競合企業を調査します。</CardDescription>
       </CardHeader>
       <CardContent>
         <ul className="space-y-2 text-sm">

--- a/apps/web/src/features/templates/TemplateNewPage.tsx
+++ b/apps/web/src/features/templates/TemplateNewPage.tsx
@@ -4,6 +4,7 @@
  */
 
 import type {
+  AgentDefinition,
   ApiError,
   ApiValidationError,
   CompetitorAnalysisParameters,
@@ -24,11 +25,19 @@ import {
 } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { fetchJson } from "@/lib/api";
+import { extractPerspectives } from "./lib/extractPerspectives";
 
 const MAX_COMPETITORS = 5;
 const MIN_COMPETITORS = 1;
@@ -227,6 +236,8 @@ export function TemplateNewPage() {
             {templateData.name} ・ {templateData.description}
           </p>
 
+          <PerspectivesPanel agents={templateData.definition.agents} />
+
           <form onSubmit={handleSubmit} noValidate className="space-y-6">
             <fieldset className="space-y-2">
               <legend className="text-sm font-medium leading-none">
@@ -406,6 +417,42 @@ function mapValidationErrors(
     }
   }
   return mappedCount > 0 ? result : null;
+}
+
+/**
+ * 実行前に「何が調査されるか」を提示する観点パネル（#228 V4）。
+ * 観点はテンプレート定義から抽出するため、選択中テンプレートに追随する。
+ * 観点が無いテンプレートでは何も表示しない（入力体験を阻害しないため）。
+ */
+function PerspectivesPanel({ agents }: { agents: AgentDefinition[] }) {
+  const perspectives = extractPerspectives(agents);
+  if (perspectives.length === 0) return null;
+
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle className="text-base">
+          調査される観点（{perspectives.length} 観点）
+        </CardTitle>
+        <CardDescription>
+          実行すると、以下の観点で競合企業を並行して調査します。
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2 text-sm">
+          {perspectives.map((perspective) => (
+            <li key={perspective.key} className="leading-tight">
+              <span className="font-medium">{perspective.name}</span>
+              <span className="text-muted-foreground">
+                {" "}
+                — {perspective.description}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
 }
 
 function FormSkeleton() {

--- a/apps/web/src/features/templates/lib/extractPerspectives.test.ts
+++ b/apps/web/src/features/templates/lib/extractPerspectives.test.ts
@@ -43,6 +43,20 @@ describe("extractPerspectives", () => {
     ]);
   });
 
+  test("investigation のみを渡すと全件を観点として返す", () => {
+    const agents: AgentDefinition[] = [
+      investigationAgent("strategy", "戦略", "事業ミッション"),
+      investigationAgent("product", "製品", "主力プロダクト"),
+    ];
+
+    const result = extractPerspectives(agents);
+
+    expect(result).toEqual([
+      { key: "strategy", name: "戦略", description: "事業ミッション" },
+      { key: "product", name: "製品", description: "主力プロダクト" },
+    ]);
+  });
+
   test("agents の並び順を保持する", () => {
     const agents: AgentDefinition[] = [
       investigationAgent("c", "C", "c-desc"),
@@ -55,8 +69,11 @@ describe("extractPerspectives", () => {
     expect(result.map((p) => p.key)).toEqual(["c", "a", "b"]);
   });
 
-  test("investigation が無い場合は空配列を返す", () => {
+  test("integration のみの場合は空配列を返す", () => {
     expect(extractPerspectives([integrationAgent])).toEqual([]);
+  });
+
+  test("空配列を渡すと空配列を返す", () => {
     expect(extractPerspectives([])).toEqual([]);
   });
 });

--- a/apps/web/src/features/templates/lib/extractPerspectives.test.ts
+++ b/apps/web/src/features/templates/lib/extractPerspectives.test.ts
@@ -9,7 +9,9 @@ function investigationAgent(
 ): AgentDefinition {
   return {
     role: "investigation",
-    agent_id: `investigation_${key}`,
+    // agent_id は抽出対象外。perspective_key と取り違える実装ミスを検出できるよう、
+    // 意図的に key と無関係な固定値にする（key 由来だとすり抜ける）。
+    agent_id: "agent-unrelated-id",
     specialization: {
       perspective_key: key,
       perspective_name_ja: nameJa,

--- a/apps/web/src/features/templates/lib/extractPerspectives.test.ts
+++ b/apps/web/src/features/templates/lib/extractPerspectives.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentDefinition } from "@agent-team-studio/shared";
+import { extractPerspectives } from "./extractPerspectives";
+
+function investigationAgent(
+  key: string,
+  nameJa: string,
+  description: string,
+): AgentDefinition {
+  return {
+    role: "investigation",
+    agent_id: `investigation_${key}`,
+    specialization: {
+      perspective_key: key,
+      perspective_name_ja: nameJa,
+      perspective_description: description,
+    },
+    system_prompt_template: "",
+  };
+}
+
+const integrationAgent: AgentDefinition = {
+  role: "integration",
+  agent_id: "integration",
+  system_prompt_template: "",
+};
+
+describe("extractPerspectives", () => {
+  test("investigation エージェントのみを観点として抽出する", () => {
+    const agents: AgentDefinition[] = [
+      investigationAgent("strategy", "戦略", "事業ミッション"),
+      investigationAgent("product", "製品", "主力プロダクト"),
+      integrationAgent,
+    ];
+
+    const result = extractPerspectives(agents);
+
+    expect(result).toEqual([
+      { key: "strategy", name: "戦略", description: "事業ミッション" },
+      { key: "product", name: "製品", description: "主力プロダクト" },
+    ]);
+  });
+
+  test("agents の並び順を保持する", () => {
+    const agents: AgentDefinition[] = [
+      investigationAgent("c", "C", "c-desc"),
+      investigationAgent("a", "A", "a-desc"),
+      investigationAgent("b", "B", "b-desc"),
+    ];
+
+    const result = extractPerspectives(agents);
+
+    expect(result.map((p) => p.key)).toEqual(["c", "a", "b"]);
+  });
+
+  test("investigation が無い場合は空配列を返す", () => {
+    expect(extractPerspectives([integrationAgent])).toEqual([]);
+    expect(extractPerspectives([])).toEqual([]);
+  });
+});

--- a/apps/web/src/features/templates/lib/extractPerspectives.ts
+++ b/apps/web/src/features/templates/lib/extractPerspectives.ts
@@ -1,0 +1,27 @@
+/**
+ * テンプレート定義の agents から「調査される観点」を抽出する純関数。
+ *
+ * 観点は investigation エージェントの specialization に紐づく（domain-types.ts）。
+ * 入力フォームで実行前に観点を提示し透明性を高めるため（#228 V4）、表示用に
+ * name / description を取り出す。テンプレート駆動なので、将来テンプレートが
+ * 複数定義されても選択中テンプレートの観点をそのまま表示できる。
+ */
+
+import type { AgentDefinition } from "@agent-team-studio/shared";
+
+/** 表示用に整形した調査観点。`key` は React の key 兼観点識別子。 */
+export type Perspective = {
+  key: string;
+  name: string;
+  description: string;
+};
+
+export function extractPerspectives(agents: AgentDefinition[]): Perspective[] {
+  return agents
+    .filter((agent) => agent.role === "investigation")
+    .map((agent) => ({
+      key: agent.specialization.perspective_key,
+      name: agent.specialization.perspective_name_ja,
+      description: agent.specialization.perspective_description,
+    }));
+}

--- a/apps/web/src/features/templates/lib/extractPerspectives.ts
+++ b/apps/web/src/features/templates/lib/extractPerspectives.ts
@@ -9,7 +9,13 @@
 
 import type { AgentDefinition } from "@agent-team-studio/shared";
 
-/** 表示用に整形した調査観点。`key` は React の key 兼観点識別子。 */
+/**
+ * 表示用に整形した調査観点。`key` は React の key 兼観点識別子。
+ *
+ * `key` は実体としては `CompetitorPerspectiveKey` だが、テンプレート駆動の
+ * 汎用表示型として将来別テンプレートの観点も受けられるよう、特定テンプレートの
+ * union に縛らず `string` のままとする（#228 AC3）。
+ */
 export type Perspective = {
   key: string;
   name: string;


### PR DESCRIPTION
## What

入力フォーム (`TemplateNewPage`) の上部に、選択中テンプレートの調査観点を実行前に常時表示するパネルを追加した。テンプレ説明と「競合企業名」入力の間に「調査される観点（N 観点）」として、各観点の名称＋説明を一覧表示する。

- `extractPerspectives`: テンプレート定義の `agents` から investigation エージェントの観点（`specialization`）を抽出する純関数
- `PerspectivesPanel`: 観点を Card で常時表示。観点が無いテンプレートでは何も描画せず入力体験を阻害しない

観点はテンプレート定義から抽出するため、新規 API・型・DB 変更は不要（フロント表示のみの改修）。

## Why

closes #228

MVP 検証 (dogfooding-log §5-6 #2) で、実行前にどの観点で調査されるかが分からず、期待との差を実行後にしか確認できない透明性課題が抽出された。実行前に観点を提示することで基準4（体験）の PASS 余地を確保する。

## How

- 観点抽出を純関数として切り出し、investigation のみを `role` でフィルタ。テンプレート駆動のため将来テンプレートが複数定義されても選択中テンプレートの観点に追随する（AC3）
- 表示件数は抽出結果から動的算出（ハードコードしない）
- type-first + テストファースト（`extractPerspectives.test.ts`: investigation のみ抽出・順序保持・空配列）

### 受け入れ条件

- [x] テンプレートに紐付く調査観点を入力フォーム上で確認できる (AC1)
- [x] 実行前に視認可能・常時表示の Card で入力体験を阻害しない (AC2)
- [x] 将来複数テンプレートでも選択中テンプレートの観点を表示できる構造 (AC3)
- [x] dogfooding で「何が調査されるか実行前に把握できる」ことを確認 (AC4) — 実機（Groq 実行）で観点パネルの表示と Investigation×4 / Integration×1 完走を確認

## Checklist

- [x] テストが通ること（該当する場合）
- [ ] ドキュメントを更新したこと（該当する場合）— 表示のみの改修のため対象なし