### PR TITLE
chore(ci): review ワークフローの Claude モデルを明示指定

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -35,3 +35,4 @@ jobs:
             念のため `.claude/skills/review/SKILL.md` を読み込み、記載された手順と出力フォーマットに従ってレビューを実施してください。
           claude_args: |
             --max-turns 20
+            --model claude-sonnet-4-6


### PR DESCRIPTION
## What

`review.yml` の `claude_args` に `--model claude-sonnet-4-6` を追加し、使用モデルを明示指定。

## Why

これまでモデルが未指定だったため、サブスクリプションプランのデフォルト（Pro: Sonnet、MAX: Opus）に依存していた。モデルを固定することで動作を再現可能にし、コスト水準も変わらず最新の Sonnet 4.6 を確実に使用できるようにする。

## How

軽微な変更のため省略。

## Checklist

- [ ] テストが通ること（該当する場合）
- [ ] ドキュメントを更新したこと（該当する場合）

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgqoR76giFDwFEEtRPGuxk)_