### PR TITLE
chore(project): bierner.markdown-mermaid を削除し VS Code 組み込み Mermaid に移行

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,6 @@
         "EditorConfig.EditorConfig",
         "DavidAnson.vscode-markdownlint",
         "yzhang.markdown-all-in-one",
-        "bierner.markdown-mermaid",
         "gruntfuggly.todo-tree",
         "streetsidesoftware.code-spell-checker",
         "vivaxy.vscode-conventional-commits",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "unwantedRecommendations": [
+    "bierner.markdown-mermaid"
+  ]
+}


### PR DESCRIPTION
## What

DevContainer の推奨拡張機能から `bierner.markdown-mermaid` を削除する。

## Why

VS Code 1.121（2026-05-20 リリース）で Mermaid レンダリングが組み込み拡張 `mermaid-markdown-features` として本体に取り込まれた。旧 `bierner.markdown-mermaid` が併存すると、両者が markdown-it プラグイン / プレビュースクリプトを二重登録して競合し、**組み込み版が無言でブロックされる**（[microsoft/vscode#317870](https://github.com/microsoft/vscode/issues/317870)）。

これが DevContainer 上で Mermaid プレビューが一瞬表示後に真っ黒になる事象の原因。`devcontainer.json` の `extensions` に旧拡張を明記しているため、コンテナ側には必ず旧拡張が入り競合が発生していた。組み込み版で代替できる（パン/ズームにも対応）ため削除する。

## How

`.devcontainer/devcontainer.json` の `extensions` 配列から `bierner.markdown-mermaid` の1行を削除。

> [!NOTE]
> ホスト側にも `bierner.markdown-mermaid` がインストールされている場合は、別途アンインストールして VS Code を完全再起動すると競合が解消する。

## Checklist

- [ ] テストが通ること（該当する場合） — N/A（設定ファイルのみ）
- [x] ドキュメントを更新したこと（該当する場合） — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)