### PR TITLE
chore(ci): update review workflow to claude-sonnet-5

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -35,4 +35,4 @@ jobs:
             念のため `.claude/skills/review/SKILL.md` を読み込み、記載された手順と出力フォーマットに従ってレビューを実施してください。
           claude_args: |
             --max-turns 20
-            --model claude-sonnet-4-6
+            --model claude-sonnet-5


### PR DESCRIPTION
## What

`.github/workflows/review.yml` の Claude Code review アクションが指定するモデルを `claude-sonnet-4-6` から `claude-sonnet-5` に更新。

## Why

Sonnet 5 がリリースされたため、リポジトリのワークフローで使用しているモデルを最新化する。

## How

`.claude/agents/*`、`.claude/skills/*` 配下も含めてモデル固定箇所を調査したが、Sonnet を固定していたのは本ワークフローのみ（他は `model: haiku` の固定が1件あるのみで対象外）。

## Checklist

- [x] テストが通ること（該当する場合） — CI 設定変更のみ、ロジック変更なし
- [ ] ドキュメントを更新したこと（該当する場合） — 該当なし


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb5jUYxLk1BmUzr3PSioJd)_